### PR TITLE
LIMS-2133 Once in a while, specs var is going empty in results reports

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -529,24 +529,17 @@ class AnalysisRequestPublishView(BrowserView):
                             if analysis.portal_type == 'Analysis' \
                             else '%s - %s' % (analysis.aq_parent.id, analysis.aq_parent.Title())
 
-        # Which analysis specs must be used?
-        # Try first with those defined at AR Publish Specs level
         if analysis.portal_type == 'ReferenceAnalysis':
             # The analysis is a Control or Blank. We might use the
             # reference results instead other specs
             uid = analysis.getServiceUID()
             specs = analysis.aq_parent.getResultsRangeDict().get(uid, {})
 
-        elif analysis.portal_type == 'DuplicateAnalysis':
-            specs = analysis.getAnalysisSpecs();
-
         else:
-            ar = analysis.aq_parent
-            specs = ar.getPublicationSpecification()
-            if not specs or keyword not in specs.getResultsRangeDict():
-                specs = analysis.getAnalysisSpecs()
-            specs = specs.getResultsRangeDict().get(keyword, {}) \
-                    if specs else {}
+            # Get the specs directly from the analysis. The getResultsRange
+            # function already takes care about which are the specs to be used:
+            # AR, client or lab.
+            specs = analysis.getResultsRange()
 
         andict['specs'] = specs
         scinot = self.context.bika_setup.getScientificNotationReport()
@@ -561,9 +554,6 @@ class AnalysisRequestPublishView(BrowserView):
             fs = '< %s' % specs['max']
         andict['formatted_specs'] = formatDecimalMark(fs, decimalmark)
         andict['formatted_uncertainty'] = format_uncertainty(analysis, analysis.getResult(), decimalmark=decimalmark, sciformat=int(scinot))
-
-        # Return specs of current analysis
-        andict['specs_dict'] = analysis.getSpecification().getResultsRangeDict().get(analysis.id)
 
         # Out of range?
         if specs:

--- a/bika/lims/browser/calcs.py
+++ b/bika/lims/browser/calcs.py
@@ -254,28 +254,35 @@ class ajaxCalculateAnalysisEntry(BrowserView):
                 else:
                     self.alerts[uid] = [alert, ]
 
+        if analysis.portal_type == 'ReferenceAnalysis':
+            # The analysis is a Control or Blank. We might use the
+            # reference results instead other specs
+            uid = analysis.getServiceUID()
+            specs = analysis.aq_parent.getResultsRangeDict().get(uid, {})
+
+        else:
+            # Get the specs directly from the analysis. The getResultsRange
+            # function already takes care about which are the specs to be used:
+            # AR, client or lab.
+            specs = analysis.getResultsRange()
+
         # format result
         belowmin = False
         abovemax = False
-        # Some analyses will not have AnalysisSpecs, eg, ReferenceAnalysis
-        if hasattr(analysis, 'getAnalysisSpecs'):
-            specs = analysis.getAnalysisSpecs()
-            specs = specs.getResultsRangeDict() if specs is not None else {}
-            specs = specs.get(analysis.getKeyword(), {})
-            hidemin = specs.get('hidemin', '')
-            hidemax = specs.get('hidemax', '')
-            if Result.get('result', ''):
-                fresult = Result['result']
-                try:
-                    belowmin = hidemin and fresult < float(hidemin) or False
-                except ValueError:
-                    belowmin = False
-                    pass
-                try:
-                    abovemax = hidemax and fresult > float(hidemax) or False
-                except ValueError:
-                    abovemax = False
-                    pass
+        hidemin = specs.get('hidemin', '')
+        hidemax = specs.get('hidemax', '')
+        if Result.get('result', ''):
+            fresult = Result['result']
+            try:
+                belowmin = hidemin and fresult < float(hidemin) or False
+            except ValueError:
+                belowmin = False
+                pass
+            try:
+                abovemax = hidemax and fresult > float(hidemax) or False
+            except ValueError:
+                abovemax = False
+                pass
 
         if belowmin is True:
             Result['formatted_result'] = '< %s' % hidemin

--- a/bika/lims/browser/worksheet/views/printview.py
+++ b/bika/lims/browser/worksheet/views/printview.py
@@ -407,16 +407,11 @@ class PrintView(BrowserView):
             uid = analysis.getServiceUID()
             specs = analysis.aq_parent.getResultsRangeDict().get(uid, {})
 
-        elif analysis.portal_type == 'DuplicateAnalysis':
-            specs = analysis.getAnalysisSpecs();
-
         else:
-            ar = analysis.aq_parent
-            specs = ar.getPublicationSpecification()
-            if not specs or keyword not in specs.getResultsRangeDict():
-                specs = analysis.getAnalysisSpecs()
-            specs = specs.getResultsRangeDict().get(keyword, {}) \
-                    if specs else {}
+            # Get the specs directly from the analysis. The getResultsRange
+            # function already takes care about which are the specs to be used:
+            # AR, client or lab.
+            specs = analysis.getResultsRange()
 
         andict['specs'] = specs
         scinot = self.context.bika_setup.getScientificNotationReport()

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -533,15 +533,15 @@ class Analysis(BaseContent):
                 rr = an.aq_parent.getResultsRange()
                 rr = [r for r in rr if r.get('keyword', '') == an.getKeyword()]
                 rr = rr[0] if rr and len(rr) > 0 else {}
-            if specification == 'ar' or rr:
+                if rr:
+                    rr['uid'] = self.UID()
+        if not rr:
+            # Let's try to retrieve the specs from client and/or lab
+            specs = an.getAnalysisSpecs(specification)
+            rr = specs.getResultsRangeDict() if specs else {}
+            rr = rr.get(an.getKeyword(), {}) if rr else {}
+            if rr:
                 rr['uid'] = self.UID()
-                return rr
-
-        specs = an.getAnalysisSpecs(specification)
-        rr = specs.getResultsRangeDict() if specs else {}
-        rr = rr.get(an.getKeyword(), {}) if rr else {}
-        if rr:
-            rr['uid'] = self.UID()
         return rr
 
     def getAnalysisSpecs(self, specification=None):
@@ -1500,4 +1500,3 @@ class Analysis(BaseContent):
 
 
 atapi.registerType(Analysis, PROJECTNAME)
-

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -11,6 +11,7 @@ LIMS-2080: Correctly interpret default (empty) values in ARImport CSV file
 LIMS-2115: Error rises when saving a Calculation
 LIMS-2116: JSONAPI throws an UnicodeDecodeError
 LIMS-2114: AR Import with Profiles, no Analyses are created
+LIMS-2133: Once in a while, specs var is going empty in results reports
 
 3.1.9 (2015-10-8)
 ------------------


### PR DESCRIPTION
Relates to https://github.com/bikalabs/Bika-LIMS/pull/1670
The AR-specific specs were not taken into account in the reports.
@henriquechehad , with this PR, the specifications are set correctly to `specs` dict key, so `specs_dict` key has been removed.