### PR TITLE
LIMS-2148 unable to sort bikalistings

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -26,6 +26,7 @@ LIMS-2121: Fix possible Horiba ICP csv handling errors
 LIMS-2042: Improving Horiba ICP to avoid Element Symbols as keywords
 LIMS-2123: Analysis Categories don't expand in Worksheet Templates
 LIMS-1993: Existing Sample look-up for AR Create in Batch does not work
+LIMS-2148: Unable to sort Bika Listing tables
 
 3.1.9 (2015-10-8)
 ------------------


### PR DESCRIPTION
Due to #1681. Sorting machinery improved.
```
2015-11-20 11:23:35 ERROR Zope.SiteErrorLog 1448015015.760.314244035684 http://localhost:8090/Plone/analysisrequests/base_view
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.analysisrequest.analysisrequests, line 741, in __call__
  Module bika.lims.browser.bika_listing, line 678, in __call__
  Module bika.lims.browser.bika_listing, line 938, in contents_table
  Module bika.lims.browser.bika_listing, line 1058, in __init__
NameError: global name 'psi' is not defined
```