### PR TITLE
LIMS-2067 Prevent initial method/instrument query for each analysis

### DIFF
--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -612,6 +612,5 @@ function WorksheetManageResultsView() {
                 });
             }
         });
-        $('table.bika-listing-table select.listing_select_entry[field="Method"]').change();
     }
 }

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -449,7 +449,8 @@ function WorksheetManageResultsView() {
                 // Is manual entry allowed for this method?
                 var request_data = {
                     catalog_name: "uid_catalog",
-                    UID: muid
+                    UID: muid,
+                    include_fields: ['ManualEntryOfResultsViewField', 'Title']
                 };
                 window.bika.lims.jsonapi_read(request_data, function(data) {
                     method = (data.objects && data.objects.length > 0) ? data.objects[0] : null;
@@ -465,7 +466,8 @@ function WorksheetManageResultsView() {
                     // Has the Analysis Service the 'Allow Instrument Entry of Results' enabled?
                     var request_data = {
                         catalog_name: "uid_catalog",
-                        UID: suid
+                        UID: suid,
+                        include_fields: ['InstrumentEntryOfResults']
                     };
                     window.bika.lims.jsonapi_read(request_data, function(asdata) {
                         service = (asdata.objects && asdata.objects.length > 0) ? asdata.objects[0] : null;


### PR DESCRIPTION
When I load worksheets after applying this PR to master, I notice that the Method and Instrument fields are already completed in the same way as they are when this code is invoked on first render.

@xispa please tell me if I'm not understanding something, or, if there are some cases where the fields must be set differently, so that I can understand what changes need to be made!