### PR TITLE
LIMS-1989 Retracting a published AR fails if one or more ASs has been retracted before publishing

### DIFF
--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -591,8 +591,11 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
         for an in analyses:
             try:
                 nan = _createObjectByType("Analysis", newar, an.getKeyword())
-            except:
-                import pdb; pdb.set_trace()
+            except Exception as e:
+                from bika.lims import logger
+                logger.warn('Cannot create analysis %s inside %s (%s)'%
+                            an.getService().Title(), newar, e)
+                continue
             nan.setService(an.getService())
             nan.setCalculation(an.getCalculation())
             nan.setInterimFields(an.getInterimFields())

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -583,8 +583,16 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
         newar.setMemberDiscount(ar.getMemberDiscount())
         # Set the results for each AR analysis
         ans = ar.getAnalyses(full_objects=True)
-        for an in ans:
-            nan = _createObjectByType("Analysis", newar, an.getKeyword())
+        # If a whole AR is retracted and contains retracted Analyses, these
+        # retracted analyses won't be created/shown in the new AR
+        workflow = getToolByName(self, "portal_workflow")
+        analyses = [x for x in ans
+                if workflow.getInfoFor(x, "review_state") not in ("retracted")]
+        for an in analyses:
+            try:
+                nan = _createObjectByType("Analysis", newar, an.getKeyword())
+            except:
+                import pdb; pdb.set_trace()
             nan.setService(an.getService())
             nan.setCalculation(an.getCalculation())
             nan.setInterimFields(an.getInterimFields())

--- a/bika/lims/tests/test_AnalysisRequest_retract.py
+++ b/bika/lims/tests/test_AnalysisRequest_retract.py
@@ -1,0 +1,78 @@
+from Products.CMFPlone.utils import _createObjectByType
+from Products.CMFCore.utils import getToolByName
+from bika.lims.utils import tmpID
+from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.idserver import renameAfterCreation
+from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_NAME
+from datetime import date
+from bika.lims.utils.analysisrequest import create_analysisrequest
+import unittest
+
+try:
+    import unittest2 as unittest
+except ImportError: # Python 2.7
+    import unittest
+
+
+class TestAnalysisRequestRetract(BikaFunctionalTestCase):
+    layer = BIKA_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestAnalysisRequestRetract, self).setUp()
+        login(self.portal, TEST_USER_NAME)
+
+    def test_retract_an_analysis_request(self):
+        #Test the retract process to avoid LIMS-1989
+        catalog = getToolByName(self.portal, 'portal_catalog')
+        # Getting the first client
+        client = self.portal.clients['client-1']
+        sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+        values = {'Client': client.UID(),
+                  'Contact': client.getContacts()[0].UID(),
+                  'SamplingDate': '2015-01-01',
+                  'SampleType': sampletype.UID()}
+        # Getting some services
+        services = catalog(portal_type = 'AnalysisService',
+                            inactive_state = 'active')[:3]
+        service_uids = [service.getObject().UID() for service in services]
+        request = {}
+        ar = create_analysisrequest(client, request, values, service_uids)
+        wf = getToolByName(ar, 'portal_workflow')
+        wf.doActionFor(ar, 'receive')
+
+        # Cheking if everything is going OK
+        #import pdb; pdb.set_trace()
+        self.assertEquals(ar.portal_workflow.getInfoFor(ar, 'review_state'),
+                                                        'sample_received')
+        for analysis in ar.getAnalyses(full_objects=True):
+            analysis.setResult('12')
+            wf.doActionFor(analysis, 'submit')
+            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
+                            'review_state'),'to_be_verified')
+            # retracting results
+            wf.doActionFor(analysis, 'retract')
+            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
+                            'review_state'),'retracted')
+        for analysis in ar.getAnalyses(full_objects=True):
+            if analysis.portal_workflow.getInfoFor(analysis,
+                'review_state') == 'retracted':
+                continue
+            wf.doActionFor(analysis, 'submit')
+            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
+                            'review_state'),'to_be_verified')
+        wf.doActionFor(ar, 'retract')
+        self.assertEquals(ar.portal_workflow.getInfoFor(ar, 'review_state'),
+                                                        'sample_received')
+
+    def tearDown(self):
+        logout()
+        super(TestAnalysisRequestRetract, self).tearDown()
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestAnalysisRequestRetract))
+    suite.layer = BIKA_FUNCTIONAL_TESTING
+    return suite

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.1.10 (unreleased)
 -------------------
 - Dashboard: replace multi-bar charts by stacked-bar charts
+LIMS-1989: Retracting a published AR fails if one or more ASs has been retracted before publishing
 LIMS-2071: Can't generate Invoice Batch/Monthly Statements
 WINE-71: Instrument. BBK WS export to FIA fails
 WINE-72: Instrument. BBK WineScan Auto Import fails


### PR DESCRIPTION
[JIRA](https://jira.bikalabs.com/browse/LIMS-1989)

pau@mendel:~/dev/Espurna/bikalims/zinstance$ bin/test -v -p -s bika.lims --suite-name='bika.lims.tests' --test='test_retract_an_analysis_request'
Test-module import failures:

Module: bika.lims.tests.test_doctests

TypeError: Module bika.lims.tests.test_doctests does not define any tests


Module: bika.lims.tests.test_robot

TypeError: Module bika.lims.tests.test_robot does not define any tests


Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.149 seconds.
  Set up plone.app.testing.layers.PloneFixture in 5.154 seconds.
  Set up bika.lims.testing.BikaTestLayer in 46.336 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                                                                               
  Ran 1 tests with 0 failures and 0 errors in 2.575 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.011 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.050 seconds.
  Tear down plone.testing.z2.Startup in 0.007 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.006 seconds.

Test-modules with import problems:
  bika.lims.tests.test_doctests
  bika.lims.tests.test_robot
pau@mendel:~/dev/Espurna/bikalims/zinstance$ 
