### PR TITLE
WINE-81: use standard jquery to parse rows for show_more button

### DIFF
--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -41,22 +41,25 @@ function BikaListingTableView() {
 			url = url.replace('_limit_from=','_olf=');
 			url += '&'+formid+"_limit_from="+limit_from;
 			$('#'+formid+' a.bika_listing_show_more').fadeOut();
+			var tbody = $('table.bika-listing-table[form_id="'+formid+'"] tbody.item-listing-tbody')
 			$.ajax(url)
 				.done(function(data) {
 					try {
-						var xmld = $.parseXML(data);
-						if (xmld.children.length > 0 && xmld.children[0].children.length > 0) {
-							var htmlcontent = xmld.children[0].children[0].innerHTML;
-							$('table.bika-listing-table[form_id="'+formid+'"] tbody.item-listing-tbody').append(htmlcontent);
-							$('#'+formid+' a.bika_listing_show_more').attr('data-limitfrom', limit_from+pagesize);
-						}
+						// We must surround <tr> inside valid TABLE tags before extracting
+						var rows = $('<html><table>'+data+'</table></html>').find('tr')
+						// Then we can simply append the rows to existing TBODY.
+						$(tbody).append(rows)
+						// Increase limit_from so that next iteration uses correct start point
+						$('#'+formid+' a.bika_listing_show_more').attr('data-limitfrom', limit_from+pagesize);
 					}
 					catch (e) {
 						$('#' + formid + ' a.bika_listing_show_more').hide();
+						console.log(e);
 					}
-								  }).fail(function () {
+				}).fail(function () {
 					$('#'+formid+' a.bika_listing_show_more').hide();
-    		}).always(function() {
+					console.log("bika_listing_show_more failed");
+    			}).always(function() {
 					var numitems = $('table.bika-listing-table[form_id="'+formid+'"] tbody.item-listing-tbody tr').length;
 					$('#'+formid+' span.number-items').html(numitems);
 					if (numitems % pagesize == 0) {

--- a/bika/lims/tests/test_bika_listing_show_more.robot
+++ b/bika/lims/tests/test_bika_listing_show_more.robot
@@ -1,0 +1,44 @@
+ *** Settings ***
+
+Library         BuiltIn
+Library         Selenium2Library  timeout=5  implicit_wait=0.2
+Library         String
+Resource        keywords.txt
+Resource        plone/app/robotframework/selenium.robot
+Library         Remote  ${PLONEURL}/RobotRemote
+Variables       plone/app/testing/interfaces.py
+Variables       bika/lims/tests/variables.py
+
+Suite Setup     Start browser
+Suite Teardown  Close All Browsers
+
+Library          DebugLibrary
+
+*** Variables ***
+
+*** Test Cases ***
+
+
+Test show_more button
+    Enable autologin as  LabManager
+    set autologin username  test_labmanager
+    Create Object   clients  Client  c01   title=Client01
+    Create Object   clients  Client  c02   title=Client02
+    Create Object   clients  Client  c03   title=Client03
+    Create Object   clients  Client  c04   title=Client04
+    Create Object   clients  Client  c05   title=Client05
+    Create Object   clients  Client  c06   title=Client06
+    Create Object   clients  Client  c07   title=Client07
+    Create Object   clients  Client  c08   title=Client08
+    Create Object   clients  Client  c09   title=Client09
+    Create Object   clients  Client  c10   title=Client10
+    go to    ${PLONEURL}/clients?list_pagesize=5
+    page should not contain      Client10
+    click element      css=.bika_listing_show_more
+    wait until page contains     Client10
+
+*** Keywords ***
+
+Start browser
+    Open browser                        ${PLONEURL}  chrome
+    Set selenium speed                  ${SELENIUM_SPEED}


### PR DESCRIPTION
XML parsing fails when XML is not valid, and it seems that the HTML returned by bika_listing is not always valid XML.  parseHTML is not implemented in the current jquery.

A simple $() works.
