### PR TITLE
LIMS-2167 Cannot assign a QC analysis to an invalid instrument

### DIFF
--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -433,7 +433,7 @@ function WorksheetManageResultsView() {
             var selectedinstr = $(instrselector).val();
             var m_manualentry = true;
             var s_instrentry  = false;
-            var qc_analysis = $(this).closest('tr,td').hasClass('qc-analysis');
+            var qc_analysis = $(this).closest('tr').hasClass('qc-analysis');
             $(instrselector).find('option').remove();
             $(instrselector).prop('disabled', false);
             $('img.alert-instruments-invalid[uid="'+auid+'"]').remove();

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -37,6 +37,7 @@ LIMS-2156: Ignore blank index values when calculating ReferenceAnalysesGroupID
 LIMS-2157: Cancelled ARs appear in AR listing inside Batches
 LIMS-2042: Horiba ICP: Missing 'DefaultResult' for imported rows
 LIMS-2030: Assign ARs in alphabetical ID order to WS
+LIMS-2167: Cannot assign a QC analysis to an invalid instrument
 
 3.1.9 (2015-10-8)
 ------------------


### PR DESCRIPTION
Although an invalid instrument cannot be assigned to an out-of-date or invalid instrument, the user should be able to add a new QC into a worksheet and assign that qc analysis to an invalid instrument. If the result set for that QC analysis is within the valid range, the instrument should automatically be available again after submit.