### PR TITLE
Fix error when labproduct's price is zero

### DIFF
--- a/bika/lims/content/labproduct.py
+++ b/bika/lims/content/labproduct.py
@@ -66,7 +66,6 @@ class LabProduct(BaseContent):
         price = self.getPrice()
         price = Decimal(price or '0.00')
         vat = Decimal(self.getVAT())
-        price = price and price or 0
         vat = vat and vat / 100 or 0
         price = price + (price * vat)
         return price.quantize(Decimal('0.00'))


### PR DESCRIPTION
This value (Decimal('0.00')) is falsish, and boolean logic cannot be used.  It results in the price being set to int(0) which has no .quantize.

Tests not required: the setupdata import/export routines which are used for robot tests, will fail if this error is present.