### PR TITLE
Analysis creation/modification subscribers now apply only to IRoutineAnalysis

### DIFF
--- a/bika/lims/subscribers/configure.zcml
+++ b/bika/lims/subscribers/configure.zcml
@@ -18,16 +18,16 @@
       handler="bika.lims.subscribers.objectmodified.ObjectModifiedEventHandler"
     />
 
-    <!-- Newly created analyses -->
+    <!-- Newly created analyses (applies to routine analyses only) -->
     <subscriber
-      for="bika.lims.interfaces.IAnalysis
+      for="bika.lims.interfaces.IRoutineAnalysis
            Products.Archetypes.interfaces.IObjectInitializedEvent"
       handler="bika.lims.subscribers.analysis.ObjectInitializedEventHandler"
     />
 
-    <!-- Deleted analyses -->
+    <!-- Deleted analyses (applies to routine analyses only) -->
     <subscriber
-      for="bika.lims.interfaces.IAnalysis
+      for="bika.lims.interfaces.IRoutineAnalysis
            zope.lifecycleevent.interfaces.IObjectRemovedEvent"
       handler="bika.lims.subscribers.analysis.ObjectRemovedEventHandler"
     />


### PR DESCRIPTION
Reject, Duplicate, Reference analyses subclass Analysis, so are mistakenly subjected to this code when they are deleted.  IAnalysis is provided directly by the Analysis class, and so can't be removed with noLongerProvides().

I've added the alsoProvides(IRoutineAnalysis) into the creation subscriber.