### PR TITLE
Always use ResourceDirectory as sticker path.

### DIFF
--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -95,7 +95,7 @@ class Sticker(BrowserView):
                  'title': <teamplate_title>,
                  'selected: True/False'}
         """
-        seltemplate = self.getSelectedTemplate()
+        path, seltemplate = self.getSelectedTemplate()
         templates = []
         for temp in getStickerTemplates():
             out = temp
@@ -120,15 +120,14 @@ class Sticker(BrowserView):
             bs_template = self.context.bika_setup.getLargeStickerTemplate()
         rq_template = self.request.get('template', bs_template)
         # Check if the template exists. If not, fallback to default's
-        if rq_template.find(':') >= 0:
+        if ':' in rq_template:
             prefix, rq_template = rq_template.split(':')
-            templates_dir = queryResourceDirectory('stickers', prefix).directory
         else:
-            this_dir = os.path.dirname(os.path.abspath(__file__))
-            templates_dir = os.path.join(this_dir, 'templates/stickers/')
+            prefix, rq_template = 'bika.lims', rq_template
+        templates_dir = queryResourceDirectory('stickers', prefix).directory
         if not os.path.isfile(os.path.join(templates_dir, rq_template)):
             rq_template = 'Code_128_1x48mm.pt'
-        return rq_template
+        return templates_dir, rq_template
 
     def getSelectedTemplateCSS(self):
         """ Looks for the CSS file from the selected template and return its
@@ -136,23 +135,13 @@ class Sticker(BrowserView):
             file named default.css in the stickers path and return its contents.
             If no CSS file found, retrns an empty string
         """
-        template = self.getSelectedTemplate()
+        templates_dir, template = self.getSelectedTemplate()
         # Look for the CSS
         content = ''
-        if template.find(':') >= 0:
-            # A template from another add-on
-            prefix, template = template.split(':')
-            resource = queryResourceDirectory('stickers', prefix)
-            css = '{0}.css'.format(template[:-3])
-            if css in resource.listDirectory():
-                content = resource.readFile(css)
-        else:
-            this_dir = os.path.dirname(os.path.abspath(__file__))
-            templates_dir = os.path.join(this_dir, 'templates/stickers/')
-            path = '%s/%s.css' % (templates_dir, template[:-3])
-            if os.path.isfile(path):
-                with open(path, 'r') as content_file:
-                    content = content_file.read()
+        fn = '{0}.css'.format(os.path.splitext(template)[0])
+        fullfn = os.path.join(templates_dir, fn)
+        if os.path.exists(fullfn):
+            content = open(fullfn, 'r').read()
         return content
 
     def nextItem(self):
@@ -175,8 +164,7 @@ class Sticker(BrowserView):
             bika.lims' Code_128_1x48mm.pt template (was sticker_small.pt).
         """
         curritem = self.nextItem()
-        templates_dir = 'templates/stickers'
-        embedt = self.getSelectedTemplate()
+        templates_dir, embedt = self.getSelectedTemplate()
         if embedt.find(':') >= 0:
             prefix, embedt = embedt.split(':')
             templates_dir = queryResourceDirectory('stickers', prefix).directory

--- a/bika/lims/vocabularies/__init__.py
+++ b/bika/lims/vocabularies/__init__.py
@@ -443,26 +443,23 @@ def getStickerTemplates():
             {'id': 'my.product:EAN128_default_small.pt',
              'title': 'my.product: EAN128 default small'}
     """
-    # Retrieve the templates from bika.lims add-on
-    p = os.path.join("browser", "templates", "stickers")
-    templates_dir = resource_filename("bika.lims", p)
-    tempath = os.path.join(templates_dir, '*.pt')
-    templates = [os.path.split(x)[-1] for x in glob.glob(tempath)]
-
-    # Retrieve the templates from other add-ons
+    templates = []
+    # Retrieve the templates from all registered 'stickers' resource
+    # directories, including bika.lims as one of them
     for templates_resource in iterDirectoriesOfType('stickers'):
         prefix = templates_resource.__name__
-        if prefix == 'bika.lims':
-            continue
         dirlist = templates_resource.listDirectory()
         exts = ['{0}:{1}'.format(prefix, tpl) for tpl in dirlist if
                 tpl.endswith('.pt')]
         templates.extend(exts)
 
+    # generate expected output as list of dictionaries.
     out = []
     templates.sort()
     for template in templates:
         title = template[:-3]
+        # We dont want to display "bika.lims:" for built-in stickers
+        title = title.replace('bika.lims:', '')
         title = title.replace('_', ' ')
         title = title.replace(':', ': ')
         out.append({'id': template,

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.1.11 (unreleased)
 -------------------
 WINE-125: Client users receive unauthorized when viewing some published ARs
+WINE-97: Always use sticker path from ResourceDirectory definition
 
 3.1.10 (2016-01-13)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '3.1.10'
+version = '3.1.11'
 
 
 def read(*rnames):


### PR DESCRIPTION
This fixes a bug where extension package stickers are resolved using bika.lims' filesystem path.