### PR TITLE
Updated for Fedora 22+

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -8,14 +8,29 @@ Linux Installation Steps
 
 1. Plone and Bika LIMS have some system dependencies
 
-    The following list of packages need to be installed.  The package list is valid
-    for Ubuntu 14.04. If you use a different distribution, you may need to find the
-    versions of these packages which are provided with your system. ::
+    The following list of packages need to be installed.  
+
+    This package list is valid for Ubuntu 14.04.
 
        sudo apt-get install python-dev build-essential libffi-dev libpcre3-dev gcc
        sudo apt-get install autoconf libtool pkg-config zlib1g-dev git-core libssl-dev
        sudo apt-get install libexpat1-dev libxslt1.1 gnuplot libpcre3 libcairo2
        sudo apt-get install libpango1.0-0 libgdk-pixbuf2.0-0
+
+    This package list is valid for Fedora 22. Similar packagaes are available and can be installed via "yum" 
+    on CentOS and older distributions of Fedora.
+
+        sudo dnf install make automake-1.15-1.fc22.noarch gcc gcc-c++-5.3.1-2.fc22.x86_64 
+        sudo dnf install kernel-devel-4.3.4-200.fc22.x86_64 gdk-pixbuf2-devel-2.31.6-1.fc22.x86_64 
+        sudo dnf install python-devel-2.7.10-8.fc22.x86_64 git-2.4.3-7.fc22.x86_64
+        sudo dnf install libffi-devel-3.1-7.fc22.x86_64 pcre-devel-8.38-1.fc22.x86_64 
+        sudo dnf install autoconf-2.69-20.fc22.noarch libtool-2.4.2-35.fc22.x86_64 
+        sudo dnf install pkgconfig-1\:0.28-8.fc22.x86_64 zlib-devel-1.2.8-7.fc22.x86_64
+        sudo dnf install openssl-devel-1\:1.0.1k-13.fc22.x86_64 expat-devel-2.1.0-10.fc22.x86_64
+        sudo dnf install libxslt-devel-1.1.28-8.fc22.x86_64 gnuplot-5.0.0-8.fc22.x86_64
+        sudo dnf install cairo-devel-1.14.2-1.fc22.x86_64 pango-devel-1.36.8-6.fc22.x86_64 
+
+    If you use a different distribution, you may need to find the versions of these packages which are provided with your system.
 
 2. Install Plone
 
@@ -26,7 +41,9 @@ Linux Installation Steps
 
     A basic command for installing a development environment in Linux::
 
-        ./install.sh --target=/path/to/Plone --build-python --static-lxml zeo
+        ./install.sh --target=/path/to/Plone --build-python zeo
+    
+    If you receive an lxml error, you may need to include the --static-lxml flag in the above command.
 
 3. Add Bika LIMS to your buildout.cfg
 
@@ -44,6 +61,9 @@ Linux Installation Steps
 
     Save the file, and then run bin/buildout again.  Buildout will download and install
     all remaining dependencies.
+
+    If you created a root installation, you will need to run buildout like this:
+        sudo -u plone_buildout bin/buildout
 
     If the download is interrupted, simply run bin/buildout again.  The process will
     be resumed.
@@ -94,6 +114,11 @@ Linux Installation Steps
 
     If you see ``INFO Zope Ready to handle requests`` then the server is running.
     Press Control+C to stop the foreground client.
+
+    If you installed Plone using a root installation, you will need to use the following commands instead:
+
+        sudo -u plone_daemon bin/zeoserver start
+        sudo -u plone_daemon bin/client1 fg
 
     To start the Plone server normally, use the following command::
 


### PR DESCRIPTION
Updated the INSTALL.rst file with latest packages for Fedora.
It now shows the list of packages users can install using dnf (yum is deprecated).