### PR TITLE
LIMS-2208 WinescanCSVParser class instance variable misspelling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Bika LIMS
 =========
 
-v3.1.12 (unreleased)
+v3.1.11 (unreleased)
 
 The meaning of Gaob
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Bika LIMS
 =========
 
-v3.1.11 (unreleased)
+v3.1.12 (unreleased)
 
 The meaning of Gaob
 -------------------

--- a/bika/lims/exportimport/instruments/foss/winescan/__init__.py
+++ b/bika/lims/exportimport/instruments/foss/winescan/__init__.py
@@ -25,7 +25,7 @@ class WinescanCSVParser(InstrumentCSVResultsFileParser):
             resid = splitted[0]
             if not resid:
                 self.err("No Sample ID found", numline=self.num_line)
-                self.currentHeader = None
+                self.currentheader = None
                 return 0
 
             duplicated = []
@@ -82,7 +82,7 @@ class WinescanCSVParser(InstrumentCSVResultsFileParser):
 
             # add result
             self._addRawResult(resid, outvals, True)
-            self.currentHeader = None
+            self.currentheader = None
             return 0
 
         self.err("No header found")

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -9,9 +9,11 @@ LIMS-1774: Shiny graphs for result ranges
 
 3.1.10 (unreleased)
 3.1.11 (unreleased)
+3.1.12 (unreleased)
 -------------------
 WINE-125: Client users receive unauthorized when viewing some published ARs
 LIMS-1991: Sort Order for Analysis Categories and Services
+- WinescanCSVParser fix
 
 3.1.10 (2016-01-13)
 -------------------

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -9,7 +9,6 @@ LIMS-1774: Shiny graphs for result ranges
 
 3.1.10 (unreleased)
 3.1.11 (unreleased)
-3.1.12 (unreleased)
 -------------------
 WINE-125: Client users receive unauthorized when viewing some published ARs
 LIMS-1991: Sort Order for Analysis Categories and Services

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '3.1.10'
+version = '3.1.12'
 
 
 def read(*rnames):
@@ -23,7 +23,7 @@ setup(name='bika.lims',
       classifiers=[
           "Framework :: Plone",
           "Programming Language :: Python",
-          "Development Status :: 5 - Production/Stable", 
+          "Development Status :: 5 - Production/Stable",
           "Environment :: Web Environment",
           "Intended Audience :: Information Technology",
           "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '3.1.12'
+version = '3.1.11'
 
 
 def read(*rnames):


### PR DESCRIPTION

Fixed bug in `bika.lims.exportimport.instruments.foss.winescan.WinescanCSVParser`

The `self.currentheader` instance variable is declared with all lowercase inside of the constructor.

 ``` python
def __init__(self, csv):
    InstrumentCSVResultsFileParser.__init__(self, csv)
    self.currentheader = None
```

This is consistent throughout the class but with two exceptions.

Lines 26-29

``` python
if not resid:
    self.err("No Sample ID found", numline=self.num_line)
    self.currentHeader = None
    return 0
```

and 

Lines 83-86
 ``` python
self._addRawResult(resid, outvals, True)
self.currentHeader = None
return 0
```
I could not find a reference to `self.currentHeader` (camelcase) in any of the parent classes so I assume this was not intended.