### PR TITLE
LIMS-2207 bugfix indentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Bika LIMS
 =========
 
-v3.1.12 (unreleased)
+v3.1.11 (unreleased)
 
 The meaning of Gaob
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Bika LIMS
 =========
 
-v3.1.11 (unreleased)
+v3.1.12 (unreleased)
 
 The meaning of Gaob
 -------------------

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -657,7 +657,7 @@ class AnalysisRequestsView(BikaListingView):
         item['SamplingDate'] = self.ulocalized_time(samplingdate, long_format=1)
         item['getDateReceived'] = self.ulocalized_time(obj.getDateReceived())
         item['getDatePublished'] = self.ulocalized_time(obj.getDatePublished())
-            items[x]['getDateVerified'] = getTransitionDate(obj, 'verify')
+        items[x]['getDateVerified'] = getTransitionDate(obj, 'verify')
 
         deviation = sample.getSamplingDeviation()
         item['SamplingDeviation'] = deviation and deviation.Title() or ''

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -657,7 +657,7 @@ class AnalysisRequestsView(BikaListingView):
         item['SamplingDate'] = self.ulocalized_time(samplingdate, long_format=1)
         item['getDateReceived'] = self.ulocalized_time(obj.getDateReceived())
         item['getDatePublished'] = self.ulocalized_time(obj.getDatePublished())
-        items[x]['getDateVerified'] = getTransitionDate(obj, 'verify')
+        item['getDateVerified'] = getTransitionDate(obj, 'verify')
 
         deviation = sample.getSamplingDeviation()
         item['SamplingDeviation'] = deviation and deviation.Title() or ''

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -9,9 +9,11 @@ LIMS-1774: Shiny graphs for result ranges
 
 3.1.10 (unreleased)
 3.1.11 (unreleased)
+3.1.12 (unreleased)
 -------------------
 WINE-125: Client users receive unauthorized when viewing some published ARs
 LIMS-1991: Sort Order for Analysis Categories and Services
+Fix error caused by extra indentation in `bika.lims.browser.analysisrequests.analysisrequest.py`
 
 3.1.10 (2016-01-13)
 -------------------

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -9,7 +9,6 @@ LIMS-1774: Shiny graphs for result ranges
 
 3.1.10 (unreleased)
 3.1.11 (unreleased)
-3.1.12 (unreleased)
 -------------------
 WINE-125: Client users receive unauthorized when viewing some published ARs
 LIMS-1991: Sort Order for Analysis Categories and Services

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '3.1.10'
+version = '3.1.12'
 
 
 def read(*rnames):
@@ -23,7 +23,7 @@ setup(name='bika.lims',
       classifiers=[
           "Framework :: Plone",
           "Programming Language :: Python",
-          "Development Status :: 5 - Production/Stable", 
+          "Development Status :: 5 - Production/Stable",
           "Environment :: Web Environment",
           "Intended Audience :: Information Technology",
           "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '3.1.12'
+version = '3.1.11'
 
 
 def read(*rnames):


### PR DESCRIPTION
Fixes failed client starts caused by indentation in `bika.lims.browser.analysisrequest.analysisrequests.py` on Line 660 when using bika.lims source in develop mode.