### PR TITLE
LIMS-2215 Decimal mark not working

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -12,6 +12,7 @@ from bika.lims.permissions import *
 from bika.lims.utils import isActive
 from bika.lims.utils import getUsers
 from bika.lims.utils import to_utf8
+from bika.lims.utils import formatDecimalMark
 from DateTime import DateTime
 from operator import itemgetter
 from Products.Archetypes.config import REFERENCE_CATALOG
@@ -310,6 +311,7 @@ class AnalysesView(BikaListingView):
         self.interim_columns = {}
         self.specs = {}
         show_methodinstr_columns = False
+        dmk = self.context.bika_setup.getResultsDecimalMark()
         for i, item in enumerate(items):
             # self.contentsMethod may return brains or objects.
             obj = hasattr(items[i]['obj'], 'getObject') and \
@@ -338,7 +340,7 @@ class AnalysesView(BikaListingView):
             # kick some pretty display values in.
             for x in range(len(interim_fields)):
                 interim_fields[x]['formatted_value'] = \
-                    format_numeric_result(obj, interim_fields[x]['value'])
+                    formatDecimalMark(interim_fields[x]['value'], dmk)
             self.interim_fields[obj.UID()] = interim_fields
             items[i]['service_uid'] = service.UID()
             items[i]['Service'] = service.Title()
@@ -584,7 +586,6 @@ class AnalysesView(BikaListingView):
             if can_view_result:
                 items[i]['Result'] = result
                 scinot = self.context.bika_setup.getScientificNotationResults()
-                dmk = self.context.bika_setup.getResultsDecimalMark()
                 items[i]['formatted_result'] = obj.getFormattedResult(sciformat=int(scinot),decimalmark=dmk)
 
                 # LIMS-1379 Allow manual uncertainty value input

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -172,7 +172,7 @@ Table cells for each column from in review_state's column list.
         <tal:comment replace="nothing"><!-- view --></tal:comment>
         <span
             tal:condition="python:not allow_edit"
-            tal:content="python:item[column]['value']"
+            tal:content="python:item[column]['formatted_value']"
             tal:attributes="class item/state_class"/>
         <input
             type="hidden"

--- a/bika/lims/tests/test_manualuncertainty.py
+++ b/bika/lims/tests/test_manualuncertainty.py
@@ -196,6 +196,8 @@ class TestManualUncertainty(BikaFunctionalTestCase):
         self.assertEqual(formatDecimalMark('1.34'), '1.34')
         self.assertEqual(formatDecimalMark('0.0021',decimalmark=','), '0,0021')
         self.assertEqual(formatDecimalMark('2'), '2')
+        self.assertEqual(formatDecimalMark('< 2.1', decimalmark=','),'< 2,1')
+        self.assertEqual(formatDecimalMark('> 2.1', decimalmark=','),'> 2,1')
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -195,7 +195,9 @@ def formatDecimalMark(value, decimalmark='.'):
         if math.isnan(vvalue):
             return vvalue
     except ValueError:
-        return value
+        # if value looks like '< 20.5', the decimal mark would have to be changed
+        if not '<' in value and not '>' in value:
+            return value
     # We have to consider the possibility of working with decimals such as
     # X.000 where those decimals are important because of the precission
     # and significant digits matters

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.x Long Term Support (LTS)
 -----------------------------
+LIMS-2215: Decimal mark not working
 LIMS-2212: Sampling round- Sampling round templates show all system analysis request templates
 LIMS-2209: error in manage analyises
 LIMS-1917: Inconsistencies related to significant digits in uncertainties


### PR DESCRIPTION
[JIRA](https://jira.bikalabs.com/browse/LIMS-2215)

pau@mendel:~/dev/labsanmartin/bikalims/bikalims/zinstance$ bin/test -v -p -s bika.lims --suite-name='bika.lims.tests' --test='test_format_decimal_mark'
Test-module import failures:

Module: bika.lims.tests.test_doctests

TypeError: Module bika.lims.tests.test_doctests does not define any tests


Module: bika.lims.tests.test_robot

TypeError: Module bika.lims.tests.test_robot does not define any tests


Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.191 seconds.
  Set up plone.app.testing.layers.PloneFixture in 6.051 seconds.
  Set up bika.lims.testing.BikaTestLayer in 45.228 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                                                                               
  Ran 1 tests with 0 failures and 0 errors in 0.013 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.011 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.053 seconds.
  Tear down plone.testing.z2.Startup in 0.007 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.004 seconds.

Test-modules with import problems:
  bika.lims.tests.test_doctests
  bika.lims.tests.test_robot
