### PR TITLE
LIMS-2216 Results below LDL are not displayed in reports

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -25,6 +25,7 @@ from smtplib import SMTPServerDisconnected, SMTPRecipientsRefused
 from zope.component import getAdapters, getUtility
 
 import App
+import cgi
 import glob, os, sys, traceback
 import Globals
 import re
@@ -542,7 +543,8 @@ class AnalysisRequestPublishView(BrowserView):
 
         andict['specs'] = specs
         scinot = self.context.bika_setup.getScientificNotationReport()
-        andict['formatted_result'] = analysis.getFormattedResult(specs=specs, sciformat=int(scinot), decimalmark=decimalmark)
+        fresult =  analysis.getFormattedResult(specs=specs, sciformat=int(scinot), decimalmark=decimalmark)
+        andict['formatted_result'] = cgi.escape(fresult);
 
         fs = ''
         if specs.get('min', None) and specs.get('max', None):
@@ -551,8 +553,8 @@ class AnalysisRequestPublishView(BrowserView):
             fs = '> %s' % specs['min']
         elif specs.get('max', None):
             fs = '< %s' % specs['max']
-        andict['formatted_specs'] = formatDecimalMark(fs, decimalmark)
-        andict['formatted_uncertainty'] = format_uncertainty(analysis, analysis.getResult(), decimalmark=decimalmark, sciformat=int(scinot))
+        andict['formatted_specs'] = cgi.escape(formatDecimalMark(fs, decimalmark))
+        andict['formatted_uncertainty'] = cgi.escape(format_uncertainty(analysis, analysis.getResult(), decimalmark=decimalmark, sciformat=int(scinot)))
 
         # Out of range?
         if specs:

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.x Long Term Support (LTS)
 -----------------------------
+LIMS-2216: Results below LDL are not displayed in reports
 LIMS-2215: Decimal mark not working
 LIMS-2203: 'Comma' as decimal mark doesnt work
 LIMS-2212: Sampling round- Sampling round templates show all system analysis request templates
@@ -9,7 +10,7 @@ LIMS-2015: Column spacing on Client look-up
 LIMS-1807: Validation for Start Date - End date relationship while creating invoices and price lists
 LIMS-1991: Sort Order for Analysis Categories and Services
 LIMS-1521: Date verified column for AR lists
-LIMS-2194 Error when submitting a result
+LIMS-2194: Error when submitting a result
 
 3.1.11 (2016-01-25)
 -------------------


### PR DESCRIPTION
Characters '<' and '>' where not escaped (`&lt;` and `$gt;`), so the character was only displayed if it did not break the html DOM. Otherwise, the char was not rendered.

Further details: [LIMS-2216: Results below LDL are not displayed in reports](Results below LDL are not displayed in reports)