### PR TITLE
LIMS-2217 Specifications are not set in analyses on Analysis Request creation

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -686,10 +686,10 @@ function AnalysisRequestAddByCol() {
         /* Configure handler for the selection of a Specification
          *
          */
-        $("[id*='_Specification']")
-            .live('selected copy',
-            function (event, item) {
-                var arnum = $(this).parents('td').attr('arnum')
+        $("tr[fieldname='Specification'] td[arnum] input[type='text']")
+            .live('selected copy', function (event, item) {
+                var arnum = get_arnum(this);
+                state_set(arnum, 'Specification', $(this).attr('uid'));
                 specification_refetch(arnum)
             })
             .each(function (i, e) {
@@ -769,7 +769,7 @@ function AnalysisRequestAddByCol() {
         var d = $.Deferred()
         var arnum_i = parseInt(arnum, 10)
         var state = bika.lims.ar_add.state[arnum_i]
-        var spec_uid = state['Specification_uid']
+        var spec_uid = state['Specification']
         if (!spec_uid) {
             d.resolve()
             return d.promise()
@@ -1667,6 +1667,7 @@ function AnalysisRequestAddByCol() {
                     var rows = $("<table>"+data+"</table>").find("tr");
                     $("[form_id='" + form_id + "'] tr[data-ajax_category='" + cat_title + "']").replaceWith(rows);
                     $(element).removeClass("collapsed").addClass("expanded");
+                    specification_apply();
                     def.resolve();
                 })
         }

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.x Long Term Support (LTS)
 -----------------------------
+LIMS-2217: Specifications are not set in analyses on Analysis Request creation
 LIMS-2215: Decimal mark not working
 LIMS-2203: 'Comma' as decimal mark doesnt work
 LIMS-2212: Sampling round- Sampling round templates show all system analysis request templates


### PR DESCRIPTION
Specifications selection in AR add form doesn't work properly.

In the Analysis Request creation form, the manual selection of the specification has no effect in the selected analyses. When a profile is not selected but a Sample Type (with an specifications associated) before expanding manually a category of the analyses, the specification is correctly set in Specification field, but has no effect in the analyses (well, since the categories are collapsed, the system cannot set the specifications to any of them). If the user expands a category of analyses and then selects a Sample Type, the Specification field is properly filled and the analyses are updated with the specifications accordingly.

In summary, there are two problems here:
1. The selection of an Specification alone has no effect in the analyses.
2. If analyses categories are not expanded, then neither the selection of sample type (with a specification assigned) nor the selection of an Specification have any effect.

[LIMS-2217 Specifications are not set in analyses on Analysis Request creation](https://jira.bikalabs.com/browse/LIMS-2217)