### PR TITLE
LIMS-2218 Result is replaced by min or max specs when "<Min" or ">Max" fields are used

### DIFF
--- a/bika/lims/browser/calcs.py
+++ b/bika/lims/browser/calcs.py
@@ -267,34 +267,12 @@ class ajaxCalculateAnalysisEntry(BrowserView):
             specs = analysis.getResultsRange()
 
         # format result
-        belowmin = False
-        abovemax = False
-        hidemin = specs.get('hidemin', '')
-        hidemax = specs.get('hidemax', '')
-        if Result.get('result', ''):
-            fresult = Result['result']
-            try:
-                belowmin = hidemin and fresult < float(hidemin) or False
-            except ValueError:
-                belowmin = False
-                pass
-            try:
-                abovemax = hidemax and fresult > float(hidemax) or False
-            except ValueError:
-                abovemax = False
-                pass
-
-        if belowmin is True:
-            Result['formatted_result'] = '< %s' % hidemin
-        elif abovemax is True:
-            Result['formatted_result'] = '> %s' % hidemax
-        else:
-            try:
-                Result['formatted_result'] = format_numeric_result(analysis,
-                                                                   Result['result'])
-            except ValueError:
-                # non-float
-                Result['formatted_result'] = Result['result']
+        try:
+            Result['formatted_result'] = format_numeric_result(analysis,
+                                                               Result['result'])
+        except ValueError:
+            # non-float
+            Result['formatted_result'] = Result['result']
         # calculate Dry Matter result
         # if parent is not an AR, it's never going to be calculable
         dm = hasattr(analysis.aq_parent, 'getReportDryMatter') and \

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.x Long Term Support (LTS)
 -----------------------------
+LIMS-2218: Result is replaced by min or max specs when "<Min" or ">Max" fields are used
 LIMS-2215: Decimal mark not working
 LIMS-2203: 'Comma' as decimal mark doesnt work
 LIMS-2212: Sampling round- Sampling round templates show all system analysis request templates


### PR DESCRIPTION
There is a problem in manage_results for those analyses that have an specification that has "<Min" and ">Max" fields defined. As a reminder, those two fields are used to show "< min" or "> max" instead of the result itself in views and reports.

The result input is updated with '< [min_value]' instead of keeping the result typed by the user when it moves the cursor out of the field. So, the system will save the min value instead of the result typed by the user. Javascript is responsible of this behavior, but this "visual replacement" of the result should only happen in read-only mode, never in write-mode.

[LIMS-2218: Result is replaced by min or max specs when "<Min" or ">Max" fields are used](https://jira.bikalabs.com/browse/LIMS-2218)

**Resolution**
The removal of the piece of code in charge of formatting the out-of-range result according to `<Min` and `>Max` restrictions (when `<Min` and `>Max` fields from specs are used) from inside `bika.lims.browser.calcs.AjaxCalculateAnalysisEntry` fixes this problem, because this service is only called (used) during edition of results via javascript. When the results have to be displayed in read-only mode, the logic to manage these behavior lives inside the .py codebehind the view, so the replacement in that case works successfully.