### PR TITLE
Fix TestHiddenAnalyses unit test

### DIFF
--- a/bika/lims/tests/test_hiddenanalyses.py
+++ b/bika/lims/tests/test_hiddenanalyses.py
@@ -264,7 +264,7 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
         ar.setAnalysisServicesSettings([])
 
         # AR with profile with no changes
-        values['Profile'] = self.analysisprofile.UID()
+        values['Profiles'] = self.analysisprofile.UID()
         ar = create_analysisrequest(client, request, values, services)
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[0]))
         self.assertFalse(ar.getAnalysisServiceSettings(services[1]).get('hidden'))
@@ -284,7 +284,7 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
 
         # AR with template with no changes
         values['Template'] = self.artemplate
-        del values['Profile']
+        del values['Profiles']
         ar = create_analysisrequest(client, request, values, services)
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[0]))
         self.assertFalse(ar.getAnalysisServiceSettings(services[1]).get('hidden'))
@@ -303,7 +303,7 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
 
         # AR with profile, with changes
-        values['Profile'] = self.analysisprofile.UID()
+        values['Profiles'] = self.analysisprofile.UID()
         del values['Template']
         matrix = [[2, 1,-2],  # AS = Not set
                   [2, 1,-2],  # AS = False
@@ -335,7 +335,7 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
 
         # AR with template, with changes
         values['Template'] = self.artemplate.UID()
-        del values['Profile']
+        del values['Profiles']
         matrix = [[2, 1,-2],  # AS = Not set
                   [2, 1,-2],  # AS = False
                   [2, 1,-1]]


### PR DESCRIPTION
This fix is required because the resolution of _[LIMS-1627 Pricing per Analysis Profile](https://jira.bikalabs.com/browse/LIMS-1627)_ involved the substution of AR's `Profile` field to `Profiles` (see https://github.com/bikalabs/bika.lims/pull/1584). This change allowed multiple Profiles per AR. In fact, the key `Profile` is no longer valid since then and when creating an AR manually, `Profiles` key must be used instead.

The test was not updated when LIMS-1627 was pushed, so it was still using `Profile`.

```
bin/test -s bika.lims -t TestHiddenAnalyses
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.300 seconds.
  Set up plone.app.testing.layers.PloneFixture in 8.478 seconds.
  Set up bika.lims.testing.BikaTestLayer in 1 minutes 17.021 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                
  Ran 4 tests with 0 failures and 0 errors in 41.968 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.021 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.103 seconds.
  Tear down plone.testing.z2.Startup in 0.008 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.008 seconds.
```