### PR TITLE
LIMS-2220 Raw display of exponential notations in results manage views

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -598,10 +598,12 @@ class AnalysesView(BikaListingView):
                     items[i]['Uncertainty'] = unc if unc else ''
                     items[i]['before']['Uncertainty'] = '&plusmn;&nbsp;';
                     items[i]['after']['Uncertainty'] = '<em class="discreet" style="white-space:nowrap;"> %s</em>' % items[i]['Unit'];
+                    items[i]['structure'] = False;
                 elif fu:
                     items[i]['Uncertainty'] = fu
                     items[i]['before']['Uncertainty'] = '&plusmn;&nbsp;';
                     items[i]['after']['Uncertainty'] = '<em class="discreet" style="white-space:nowrap;"> %s</em>' % items[i]['Unit'];
+                    items[i]['structure'] = True
 
                 # LIMS-1700. Allow manual input of Detection Limits
                 # LIMS-1775. Allow to select LDL or UDL defaults in results with readonly mode

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -544,7 +544,15 @@ class AnalysisRequestPublishView(BrowserView):
         andict['specs'] = specs
         scinot = self.context.bika_setup.getScientificNotationReport()
         fresult =  analysis.getFormattedResult(specs=specs, sciformat=int(scinot), decimalmark=decimalmark)
-        andict['formatted_result'] = cgi.escape(fresult);
+
+        # We don't use here cgi.encode because results fields must be rendered
+        # using the 'structure' wildcard. The reason is that the result can be
+        # expressed in sci notation, that may include <sup></sup> html tags.
+        # Please note the default value for the 'html' parameter from
+        # getFormattedResult signature is set to True, so the service will
+        # already take into account LDLs and UDLs symbols '<' and '>' and escape
+        # them if necessary.
+        andict['formatted_result'] = fresult;
 
         fs = ''
         if specs.get('min', None) and specs.get('max', None):

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -561,8 +561,8 @@ class AnalysisRequestPublishView(BrowserView):
             fs = '> %s' % specs['min']
         elif specs.get('max', None):
             fs = '< %s' % specs['max']
-        andict['formatted_specs'] = cgi.escape(formatDecimalMark(fs, decimalmark))
-        andict['formatted_uncertainty'] = cgi.escape(format_uncertainty(analysis, analysis.getResult(), decimalmark=decimalmark, sciformat=int(scinot)))
+        andict['formatted_specs'] = formatDecimalMark(fs, decimalmark)
+        andict['formatted_uncertainty'] = format_uncertainty(analysis, analysis.getResult(), decimalmark=decimalmark, sciformat=int(scinot))
 
         # Out of range?
         if specs:

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -214,8 +214,12 @@ Table cells for each column from in review_state's column list.
                 value python:item[column] if item[column] is not None else '';"/>
         <tal:comment replace="nothing"><!-- view --></tal:comment>
         <span
-            tal:condition="python:not allow_edit and column == 'Result'"
-            tal:content="python:item['formatted_result'] if item['formatted_result'] is not None else item[column]"
+            tal:condition="python:not allow_edit and column == 'Result' and item.get('formatted_result', '')"
+            tal:content="structure python:item['formatted_result']"
+            tal:attributes="class item/state_class"/>
+        <span
+            tal:condition="python:not allow_edit and column == 'Result' and not item.get('formatted_result', '')"
+            tal:content="python:item['formatted_result']"
             tal:attributes="class item/state_class"/>
         <span
             tal:condition="python:not allow_edit and column != 'Result'"
@@ -245,7 +249,7 @@ Table cells for each column from in review_state's column list.
                 uid item/uid;
                 objectId string:${item/id};
                 size input_width;"
-            tal:content="python:item['formatted_result']"/>
+            tal:content="structure python:item['formatted_result']"/>
         <input
             type="hidden"
             tal:attributes="
@@ -322,9 +326,12 @@ Table cells for each column from in review_state's column list.
                     value python:item[column];
                     name string:${column}.${item/uid}:records"/>
         </span>
-        <span
-            tal:content="python:item.has_key('formatted_result') and item['formatted_result'] or item[column]"
-            tal:attributes="class string:${item/state_class} result"/>
+        <span tal:condition="python:item.get('formatted_result','')"
+              tal:content="structure python:item['formatted_result']"
+              tal:attributes="class string:${item/state_class} result"/>
+        <span tal:condition="python:not item.get('formatted_result','')"
+              tal:content="python:item[column]"
+              tal:attributes="class string:${item/state_class} result"/>
     </span>
 </span>
 

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -221,10 +221,14 @@ Table cells for each column from in review_state's column list.
             tal:condition="python:not allow_edit and column == 'Result' and not item.get('formatted_result', '')"
             tal:content="python:item['formatted_result']"
             tal:attributes="class item/state_class"/>
-        <span
-            tal:condition="python:not allow_edit and column != 'Result'"
+        <tal:regularlabel condition="python:not allow_edit and column != 'Result'">
+        <span tal:condition="python:item.get('structure',False)"
+            tal:content="structure python:item[column] if item[column] is not None else ''"
+            tal:attributes="class item/state_class"/>
+        <span tal:condition="python:not item.get('structure',False)"
             tal:content="python:item[column] if item[column] is not None else ''"
             tal:attributes="class item/state_class"/>
+        </tal:regularlabel>
         <input
             type="hidden"
             tal:condition="python:not allow_edit"

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -869,8 +869,9 @@ class Analysis(BaseContent):
             try:
                 res = float(result) # required, check if floatable
                 res = drop_trailing_zeros_decimal(res)
+                fdm = formatDecimalMark(res, decimalmark)
                 hdl = cgi.escape(dl) if html else dl
-                return formatDecimalMark('%s %s' % (hdl, res), decimalmark)
+                return '%s %s' % (hdl, fdm)
             except:
                 logger.warn("The result for the analysis %s is a "
                             "detection limit, but not floatable: %s" %

--- a/bika/lims/tests/test_limitdetections.py
+++ b/bika/lims/tests/test_limitdetections.py
@@ -338,7 +338,12 @@ class TestLimitDetections(BikaFunctionalTestCase):
             self.assertEqual(an.isUpperDetectionLimit(), case['isudl'])
             self.assertEqual(float(an.getResult()), case['expresult'])
             #import pdb; pdb.set_trace()
-            self.assertEqual(an.getFormattedResult(), case['expformattedresult'])
+            self.assertEqual(an.getFormattedResult(html=False), case['expformattedresult'])
+            expres = case['expformattedresult']
+            expres = expres.replace('< ', '&lt; ') if an.isBelowLowerDetectionLimit() else expres
+            expres = expres.replace('> ', '&gt; ') if an.isAboveUpperDetectionLimit() else expres
+            self.assertEqual(an.getFormattedResult(html=True), expres)
+            self.assertEqual(an.getFormattedResult(), expres)
 
     def test_ar_manageresults_limitdetections(self):
         # Input results
@@ -379,18 +384,24 @@ class TestLimitDetections(BikaFunctionalTestCase):
             self.assertFalse(an.isAboveUpperDetectionLimit())
             self.assertFalse(an.getDetectionLimitOperand())
             self.assertEqual(an.getFormattedResult(), '15.00')
+            self.assertEqual(an.getFormattedResult(html=True), '15.00')
+            self.assertEqual(an.getFormattedResult(html=False), '15.00')
             an.setResult('-1')
             self.assertEqual(float(an.getResult()), -1)
             self.assertTrue(an.isBelowLowerDetectionLimit())
             self.assertFalse(an.isAboveUpperDetectionLimit())
             self.assertFalse(an.getDetectionLimitOperand())
-            self.assertEqual(an.getFormattedResult(), '< %s' % (self.lds[idx]['min']))
+            self.assertEqual(an.getFormattedResult(html=False), '< %s' % (self.lds[idx]['min']))
+            self.assertEqual(an.getFormattedResult(html=True), '&lt; %s' % (self.lds[idx]['min']))
+            self.assertEqual(an.getFormattedResult(), '&lt; %s' % (self.lds[idx]['min']))
             an.setResult('2000')
             self.assertEqual(float(an.getResult()), 2000)
             self.assertFalse(an.isBelowLowerDetectionLimit())
             self.assertTrue(an.isAboveUpperDetectionLimit())
             self.assertFalse(an.getDetectionLimitOperand())
-            self.assertEqual(an.getFormattedResult(), '> %s' % (self.lds[idx]['max']))
+            self.assertEqual(an.getFormattedResult(html=False), '> %s' % (self.lds[idx]['max']))
+            self.assertEqual(an.getFormattedResult(html=True), '&gt; %s' % (self.lds[idx]['max']))
+            self.assertEqual(an.getFormattedResult(), '&gt; %s' % (self.lds[idx]['max']))
 
             # Set a DL result
             an.setResult('<15')
@@ -399,11 +410,15 @@ class TestLimitDetections(BikaFunctionalTestCase):
                 self.assertTrue(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
                 self.assertEqual(an.getDetectionLimitOperand(), '<')
-                self.assertEqual(an.getFormattedResult(), '< 15')
+                self.assertEqual(an.getFormattedResult(html=False), '< 15')
+                self.assertEqual(an.getFormattedResult(html=True), '&lt; 15')
+                self.assertEqual(an.getFormattedResult(), '&lt; 15')
             else:
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
                 self.assertFalse(an.getDetectionLimitOperand())
+                self.assertEqual(an.getFormattedResult(html=False), '15.00')
+                self.assertEqual(an.getFormattedResult(html=True), '15.00')
                 self.assertEqual(an.getFormattedResult(), '15.00')
 
             an.setResult('>15')
@@ -412,11 +427,15 @@ class TestLimitDetections(BikaFunctionalTestCase):
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertTrue(an.isAboveUpperDetectionLimit())
                 self.assertEqual(an.getDetectionLimitOperand(), '>')
-                self.assertEqual(an.getFormattedResult(), '> 15')
+                self.assertEqual(an.getFormattedResult(html=False), '> 15')
+                self.assertEqual(an.getFormattedResult(html=True), '&gt; 15')
+                self.assertEqual(an.getFormattedResult(), '&gt; 15')
             else:
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
                 self.assertFalse(an.getDetectionLimitOperand())
+                self.assertEqual(an.getFormattedResult(html=False), '15.00')
+                self.assertEqual(an.getFormattedResult(html=True), '15.00')
                 self.assertEqual(an.getFormattedResult(), '15.00')
 
             # Set a DL result explicitely
@@ -427,11 +446,15 @@ class TestLimitDetections(BikaFunctionalTestCase):
                 self.assertTrue(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
                 self.assertEqual(an.getDetectionLimitOperand(), '<')
-                self.assertEqual(an.getFormattedResult(), '< 15')
+                self.assertEqual(an.getFormattedResult(html=False), '< 15')
+                self.assertEqual(an.getFormattedResult(html=True), '&lt; 15')
+                self.assertEqual(an.getFormattedResult(), '&lt; 15')
             else:
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
                 self.assertFalse(an.getDetectionLimitOperand())
+                self.assertEqual(an.getFormattedResult(html=False), '15.00')
+                self.assertEqual(an.getFormattedResult(html=True), '15.00')
                 self.assertEqual(an.getFormattedResult(), '15.00')
 
             an.setDetectionLimitOperand('>')
@@ -441,11 +464,15 @@ class TestLimitDetections(BikaFunctionalTestCase):
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertTrue(an.isAboveUpperDetectionLimit())
                 self.assertEqual(an.getDetectionLimitOperand(), '>')
-                self.assertEqual(an.getFormattedResult(), '> 15')
+                self.assertEqual(an.getFormattedResult(html=False), '> 15')
+                self.assertEqual(an.getFormattedResult(html=True), '&gt; 15')
+                self.assertEqual(an.getFormattedResult(), '&gt; 15')
             else:
                 self.assertFalse(an.isBelowLowerDetectionLimit())
                 self.assertFalse(an.isAboveUpperDetectionLimit())
                 self.assertFalse(an.getDetectionLimitOperand())
+                self.assertEqual(an.getFormattedResult(html=False), '15.00')
+                self.assertEqual(an.getFormattedResult(html=True), '15.00')
                 self.assertEqual(an.getFormattedResult(), '15.00')
 
 

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -196,8 +196,12 @@ def formatDecimalMark(value, decimalmark='.'):
             return vvalue
     except ValueError:
         # if value looks like '< 20.5', the decimal mark would have to be changed
-        if not '<' in value and not '>' in value:
+        if value and value[:1] in ['<','>']:
+            fdm = formatDecimalMark(value[1:].strip())
+            return '%s %s' % (value[:1], fdm)
+        else:
             return value
+
     # We have to consider the possibility of working with decimals such as
     # X.000 where those decimals are important because of the precission
     # and significant digits matters
@@ -207,13 +211,9 @@ def formatDecimalMark(value, decimalmark='.'):
     # strings for results
     rawval = str(value)
     try:
-        if decimalmark == ',':
-            rawval = rawval.replace('.', '[comma]')
-            rawval = rawval.replace(',', '.')
-            rawval = rawval.replace('[comma]', ',')
+        return decimalmark.join(rawval.split('.'))
     except:
-        pass
-    return rawval
+        return rawval
 
 
 # encode_header function copied from roundup's rfc2822 package.

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -197,7 +197,7 @@ def formatDecimalMark(value, decimalmark='.'):
     except ValueError:
         # if value looks like '< 20.5', the decimal mark would have to be changed
         if value and value[:1] in ['<','>']:
-            fdm = formatDecimalMark(value[1:].strip())
+            fdm = formatDecimalMark(value[1:].strip(), decimalmark)
             return '%s %s' % (value[:1], fdm)
         else:
             return value

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.x Long Term Support (LTS)
 -----------------------------
+LIMS-2220: Raw display of exponential notations in results manage views
 LIMS-2216: Results below LDL are not displayed in reports
 LIMS-2217: Specifications are not set in analyses on Analysis Request creation
 LIMS-2218: Result is replaced by min or max specs when "<Min" or ">Max" fields are used


### PR DESCRIPTION
Results formatted with scientific notations with exponents are not displayed correctly in manage results views. The HTML tags for superindexes `<sup></sup>` are not rendered, but escaped and displayed in raw mode. Need to add the structure wildcard in the DOM elements from bika_listing_item template where formatted_results values are placed.

Similar problem in results reports. We added cgi.encode earlier (see PR[#1774 LIMS-2216 Results below LDL are not displayed in reports](https://github.com/bikalabs/bika.lims/pull/1774)) in order to make Detection Limits (LDL and UDL) symbols ('>' and '<') visible, but we didn't take into account the Sci notation.

```
$ bin/test -m bika.lims --layer=bika.lims.testing.BikaTestingLayer:Functional
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.210 seconds.
  Set up plone.app.testing.layers.PloneFixture in 7.550 seconds.
  Set up bika.lims.testing.BikaTestLayer in 1 minutes 3.740 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                  
  Ran 39 tests with 0 failures and 0 errors in 3 minutes 56.695 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.017 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.077 seconds.
  Tear down plone.testing.z2.Startup in 0.008 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.010 seconds.
```