### PR TITLE
LIMS-2225 Formatted results not displayed properly in Worksheet's transposed layout

### DIFF
--- a/bika/lims/browser/worksheet/templates/analyses_transposed_cell.pt
+++ b/bika/lims/browser/worksheet/templates/analyses_transposed_cell.pt
@@ -144,11 +144,12 @@
                 <!-- Calculated result field -->
                 <span
                     tal:attributes="
+                        class string:result;
                         field string:formatted_result;
                         uid item/uid;
                         objectId string:${item/id};
                         size input_width;"
-                    tal:content="python:item['formatted_result']"/>
+                    tal:content="structure python:item['formatted_result']"/>
                 <input
                     type="hidden"
                     tal:attributes="
@@ -207,7 +208,7 @@
                 </tal:edit>
                 <tal:view condition="python:not allow_edit"
                     tal:define="val python:item.get(column, '')">
-                    <span tal:content="python:item.get('formatted_result', val)"
+                    <span tal:content="structure python:item.get('formatted_result', val)"
                           tal:attributes="class python:item.get('state_class') + ' result'"/>
                     <!-- String result -->
                     <tal:stringresult tal:condition="python:field_type=='string'">
@@ -238,13 +239,15 @@
                 </tal:view>
             </tal:regular_result>
 
+            <!-- Uncertainty -->
+            <span class="result-uncertainty"
+            tal:content="python:'%s %s' % ('&plusmn;', item.get('Uncertainty', ''))"
+            tal:condition="python:item.get('Uncertainty', '')"/>
+
             <!-- Units -->
             <em class="discreet"
                 style="white-space:nowrap;"
                 tal:content="structure python:item.get('Unit', '')"/>
-
-            <!-- Uncertainty -->
-            <span tal:content="python:item.get('Uncertainty', '')"/>
 
             <!-- Retested? -->
             <input

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.x Long Term Support (LTS)
 -----------------------------
+LIMS-2225: Formatted results not displayed properly in Worksheet's transposed layout
 LIMS-2221: Decimal mark doesn't work in Sci Notation
 LIMS-2219: Using a SciNotation diferent from 'aE+b / aE-b' throws an error
 LIMS-2220: Raw display of exponential notations in results manage views


### PR DESCRIPTION
In worksheet's transposed layout, the result fields in read-only mode are not displayed correctly when the result is below the LDL, the result is above the UDL or when a SciNotation other than the first one is selected. Basically, the result is not rendered as "structure" in the template.

![lims-2225](https://cloud.githubusercontent.com/assets/832627/14120007/2509f21a-f5f1-11e5-8b85-fc293a1739ae.png)
