### PR TITLE
LIMS-1809. Typos. Perdiod and missing spaces

### DIFF
--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -105,10 +105,10 @@ class FolderView(BikaListingView):
             'QC': {'title': _('QC'),
                    'sortable':False,
                    'toggle': False},
-            'QCTotals': {'title': _('QC Samples(Analyses)'),
+            'QCTotals': {'title': _('QC Samples (Analyses)'),
                    'sortable':False,
                    'toggle': False},
-            'RoutineTotals': {'title': _('Routine Samples(Analyses)'),
+            'RoutineTotals': {'title': _('Routine Samples (Analyses)'),
                    'sortable':False,
                    'toggle': False},
             'CreationDate': {'title': PMF('Date Created'),
@@ -296,7 +296,7 @@ class FolderView(BikaListingView):
 
             priority = obj.getPriority()
             items[x]['Priority'] = ''
-            
+
             instrument = obj.getInstrument()
             items[x]['Instrument'] = instrument and instrument.Title() or ''
 

--- a/bika/lims/controlpanel/bika_sampletypes.py
+++ b/bika/lims/controlpanel/bika_sampletypes.py
@@ -51,7 +51,7 @@ class SampleTypesView(BikaListingView):
                           'toggle': True},
             'getMinimumVolume': {'title': _('Minimum Volume'),
                                  'toggle': True},
-            'RetentionPeriod': {'title': _('Retention Perdiod'),
+            'RetentionPeriod': {'title': _('Retention Period'),
                              'toggle': True},
             'SampleMatrix': {'title': _('SampleMatrix'),
                              'toggle': True},
@@ -66,39 +66,39 @@ class SampleTypesView(BikaListingView):
              'title': _('Active'),
              'contentFilter': {'inactive_state': 'active'},
              'transitions': [{'id':'deactivate'}, ],
-             'columns': ['Title', 
-                         'Description', 
+             'columns': ['Title',
+                         'Description',
                          'getHazardous',
-                         'RetentionPeriod', 
-                         'SampleMatrix', 
-                         'ContainerType', 
-                         'getSamplePoints', 
-                         'getPrefix', 
+                         'RetentionPeriod',
+                         'SampleMatrix',
+                         'ContainerType',
+                         'getSamplePoints',
+                         'getPrefix',
                          'getMinimumVolume']},
             {'id':'inactive',
              'title': _('Dormant'),
              'contentFilter': {'inactive_state': 'inactive'},
              'transitions': [{'id':'activate'}, ],
-             'columns': ['Title', 
-                         'Description', 
-                         'getHazardous', 
-                         'RetentionPeriod', 
-                         'SampleMatrix', 
-                         'ContainerType', 
-                         'getSamplePoints', 
-                         'getPrefix', 
+             'columns': ['Title',
+                         'Description',
+                         'getHazardous',
+                         'RetentionPeriod',
+                         'SampleMatrix',
+                         'ContainerType',
+                         'getSamplePoints',
+                         'getPrefix',
                          'getMinimumVolume']},
             {'id':'all',
              'title': _('All'),
              'contentFilter':{},
-             'columns': ['Title', 
-                         'Description', 
-                         'getHazardous', 
-                         'RetentionPeriod', 
-                         'SampleMatrix', 
-                         'ContainerType', 
-                         'getSamplePoints', 
-                         'getPrefix', 
+             'columns': ['Title',
+                         'Description',
+                         'getHazardous',
+                         'RetentionPeriod',
+                         'SampleMatrix',
+                         'ContainerType',
+                         'getSamplePoints',
+                         'getPrefix',
                          'getMinimumVolume']},
         ]
 
@@ -113,7 +113,7 @@ class SampleTypesView(BikaListingView):
 
             if obj.getRetentionPeriod():
                 items[x]['RetentionPeriod'] = "hours: " + str(obj.getRetentionPeriod()['hours']) + " minutes: " + str(obj.getRetentionPeriod()['minutes']) + " days: " + str(obj.getRetentionPeriod()['days'])
-                
+
             else:
                 items[x]['RetentionPeriod'] = ''
 
@@ -139,7 +139,7 @@ class SampleTypesView(BikaListingView):
                         SPLine += token.Title() + ", "
                         urlStr += "<a href='%s'>%s</a>" % (token.absolute_url(),token.Title())
                     items[x]['replace']['getSamplePoints'] = urlStr
-                    
+
                 else:
                     items[x]['getSamplePoints'] = obj.getSamplePoints()[0].Title()
                     items[x]['replace']['getSamplePoints'] = "<a href='%s'>%s</a>" % \

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.1.x Long Term Support (LTS)
 -----------------------------
+LIMS-1809: Typos. Perdiod an missing spaces
 LIMS-2221: Decimal mark doesn't work in Sci Notation
 LIMS-2219: Using a SciNotation diferent from 'aE+b / aE-b' throws an error
 LIMS-2220: Raw display of exponential notations in results manage views


### PR DESCRIPTION
Misspelings: "Perdiod" to "Period". "QC Samples(Analyses)" to "QC Samples (Analyses)" and "Routine Samples(Analyses)" to "Routine Samples (Analyses)". Transifex's repos will be updated with the next release (3.1.11).