### PR TITLE
Change report attachment file name to AR

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -797,7 +797,7 @@ class AnalysisRequestPublishView(BrowserView):
 
             # Attach the pdf to the email if requested
             if pdf_report and 'pdf' in recip.get('pubpref'):
-                attachPdf(mime_msg, pdf_report, pdf_fn)
+                attachPdf(mime_msg, pdf_report, ar.id)
 
             # For now, I will simply ignore mail send under test.
             if hasattr(self.portal, 'robotframework'):


### PR DESCRIPTION
Change report attachment file name to AR.

PDF attachments on published reports had a random temp file name rather than a meaningful name.  This changes the name to the analysis request id.