### PR TITLE
HEALTH-569 Bar code printing not working on sample registration

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -2404,11 +2404,11 @@ function AnalysisRequestAddByCol() {
                             window.bika.lims.portalMessage(msg)
                             window.scroll(0, 0)
                         }
-                        else if (data['labels']) {
+                        else if (data['stickers']) {
                             var destination = window.location.href.split("/portal_factory")[0]
-                            var ars = data['labels']
-                            var labelsize = data['labelsize']
-                            var q = "/sticker?size=" + labelsize + "&items=" + ars.join(",")
+                            var ars = data['stickers']
+                            var stickertemplate = data['stickertemplate']
+                            var q = "/sticker?autoprint=1&template=" + stickertemplate + "&items=" + ars.join(",")
                             window.location.replace(destination + q)
                         }
                         else {

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,3 +1,7 @@
+3.1.12 (unreleased)
+-----------------------------
+HEALTH-569 Bar code printing not working on sample registration
+
 3.1.11 (2016-04-22)
 -----------------------------
 LIMS-2223: Saving a recordswidget as hidden fails


### PR DESCRIPTION
When bar codes are set to be printed at Sample Registration the bar code is not been printed.

Regression due to [LIMS-1539 Printable Worksheets. In both AR by row or column orientations](https://github.com/bikalabs/bika.lims/pull/1434), missed to apply changes in ar-add.js