### PR TITLE
LIMS-2252 Partitions not submitted when creating AR if the form is submitted before partitions are calculated

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -2113,6 +2113,11 @@ function AnalysisRequestAddByCol() {
             sampletype: st_uid,
             _authenticator: $("input[name='_authenticator']").val()
         }
+
+        // HEALTH-593 Partitions not submitted when creating AR
+        // Disable the Add button until the partitions get calculated
+        $('input[name="save_button"]').prop('disabled', true);
+
         window.jsonapi_cache = window.jsonapi_cache || {}
         var cacheKey = $.param(request_data)
         if (typeof window.jsonapi_cache[cacheKey] === "undefined") {
@@ -2130,6 +2135,9 @@ function AnalysisRequestAddByCol() {
                                window.jsonapi_cache[cacheKey] = data
                                bika.lims.ar_add.state[arnum]['Partitions'] = data['parts']
                            }
+                           // HEALTH-593 Partitions not submitted when creating AR
+                           // Enable the Add button, partitions calculated
+                           $('input[name="save_button"]').prop('disabled', false);
                            d.resolve()
                        }
                    })
@@ -2137,6 +2145,9 @@ function AnalysisRequestAddByCol() {
         else {
             var data = window.jsonapi_cache[cacheKey]
             bika.lims.ar_add.state[arnum]['Partitions'] = data['parts']
+            // HEALTH-593 Partitions not submitted when creating AR
+            // Enable the Add button, partitions calculated
+            $('input[name="save_button"]').prop('disabled', false);
             d.resolve()
         }
         return d.promise()

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -4,6 +4,7 @@ HEALTH-569 Bar code printing not working on sample registration
 
 3.1.11 (2016-04-22)
 -----------------------------
+LIMS-2252: Partitions not submitted when creating AR if the form is submitted before partitions are calculated
 LIMS-2223: Saving a recordswidget as hidden fails
 LIMS-2225: Formatted results not displayed properly in Worksheet's transposed layout
 LIMS-2001: Duplicate for one analysis only


### PR DESCRIPTION
When you select an analysis' checkbox (in AR add view), it should place the '1' to the right, indicating that this analysis is against first partition of the sample. If you submit the form before the partition number is calculated (via ajax!) then the form fails:

```
Traceback (innermost last):
Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module bika.health.browser.analysisrequest.ajax, line 54, in _call_
Module bika.lims.browser.analysisrequest.add, line 461, in _call_
Module bika.lims.browser.analysisrequest.add, line 602, in create_analysisrequest
KeyError: 'Partitions'
```