### PR TITLE
Remove confusing try except in a test

### DIFF
--- a/bika/lims/tests/test_AnalysisRequest_retract.py
+++ b/bika/lims/tests/test_AnalysisRequest_retract.py
@@ -41,10 +41,7 @@ class TestAnalysisRequestRetract(BikaFunctionalTestCase):
         request = {}
         ar = create_analysisrequest(client, request, values, service_uids)
         wf = getToolByName(ar, 'portal_workflow')
-        try:
-            wf.doActionFor(ar, 'receive')
-        except WorkflowException:
-            pass
+        wf.doActionFor(ar, 'receive')
 
         # Cheking if everything is going OK
         #import pdb; pdb.set_trace()


### PR DESCRIPTION
As a general rule, better to not use try-except:pass, and if there is no other option (because is caused by an undiscovered Plone's bug), then at least add a logger.warn 'someting' before the pass. In any case, never use try-execpts in tests, cause one could think the test did not passed because an assert was violated instead of an unknown 3rd-party bug (test failed versus error).