### PR TITLE
Fix doctest failure in bika.lims.jsonapi.update

### DIFF
--- a/bika/lims/jsonapi/update.py
+++ b/bika/lims/jsonapi/update.py
@@ -107,6 +107,7 @@ class Update(object):
         ppath = context.portal_url.getPortalObject().getPhysicalPath()
         if ppath and len(ppath) > 1:
             ppath = ppath[1]
+            ppath = ppath if ppath.startswith('/') else '/' + ppath
             obj = context.restrictedTraverse(ppath + obj_path)
 
         if not obj:


### PR DESCRIPTION
Failure in test update (bika.lims.jsonapi.update.Update)
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/usr/lib/python2.7/doctest.py", line 2201, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for bika.lims.jsonapi.update.Update.update
  File "/home/travis/build/bikalabs/bika.lims/bika/lims/jsonapi/update.py", line 23, in update