### PR TITLE
 Fix doctest failure in bika.lims.jsonapi.update (3.2)

### DIFF
--- a/bika/lims/jsonapi/update.py
+++ b/bika/lims/jsonapi/update.py
@@ -110,9 +110,12 @@ class Update(object):
             obj_path = self.request['obj_path']
             site_path = context.portal_url.getPortalObject().getPhysicalPath()
             if site_path and isinstance(site_path, basestring):
+                site_path = site_path if site_path.startswith('/') else '/' + site_path
                 obj = context.restrictedTraverse(site_path + obj_path)
             elif site_path and len(site_path) > 1:
-                obj = context.restrictedTraverse(site_path[1] + obj_path)
+                site_path = site_path[1]
+                site_path = site_path if site_path.startswith('/') else '/' + site_path
+                obj = context.restrictedTraverse(site_path + obj_path)
 
         if obj:
             self.used('obj_uid')


### PR DESCRIPTION
```
Failure in test update (bika.lims.jsonapi.update.Update)
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/usr/lib/python2.7/doctest.py", line 2201, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for bika.lims.jsonapi.update.Update.update
  File "/home/travis/build/bikalabs/bika.lims/bika/lims/jsonapi/update.py", line 24, in update
```