### PR TITLE
LIMS-2299: Add ui for editing ar_count in all analysisrequest lists.

### DIFF
--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -1,5 +1,6 @@
 from AccessControl import getSecurityManager
 from Products.CMFCore.permissions import ModifyPortalContent
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t
 from bika.lims.browser.bika_listing import BikaListingView
@@ -17,6 +18,8 @@ from zope.interface import implements
 class AnalysisRequestsView(BikaListingView):
     """Base for all lists of ARs
     """
+    template = ViewPageTemplateFile("templates/analysisrequests.pt")
+    ar_add = ViewPageTemplateFile("templates/ar_add.pt")
     implements(IViewView)
 
     def __init__(self, context, request):

--- a/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
@@ -16,44 +16,44 @@
 		table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
 	tal:condition="python:not table_only">
     <h1>
-		<img tal:condition="view/icon | nothing"
-			 src="" tal:attributes="src view/icon"/>
+        <img tal:condition="view/icon | nothing"
+             src="" tal:attributes="src view/icon"/>
         <img tal:condition="view/getPriorityIcon | nothing"
              src="" tal:attributes="src view/getPriorityIcon"/>
-		<span style="position:relative;top:-0.2em;" class="documentFirstHeading" tal:content="view/title"/>
-		<tal:add_actions repeat="add_item python:view.context_actions.keys()">
-			<a tal:attributes="
+        <span style="position:relative;top:-0.2em;" class="documentFirstHeading" tal:content="view/title"/>
+        <tal:add_actions repeat="add_item python:view.context_actions.keys()">
+            <a tal:attributes="
 				style python:'background: url(%s) 2px 50%% no-repeat'%(view.context_actions[add_item]['icon']);
 				href python:view.context_actions[add_item]['url'];
 				class python:'context_action_link %s' % (view.context_actions[add_item].get('class',''))">
-				<span tal:replace="python:add_item"/>
-			</a>
-		</tal:add_actions>
-		<select name="ar_count"
-			class='ar_count' style="vertical-align:top !important"
-			tal:condition="python:len(view.context_actions) > 0">
-			<option value='1' i18n:translate="">1</option>
-			<option value='2' i18n:translate="">2</option>
-			<option value='3' i18n:translate="">3</option>
-			<option value='4' i18n:translate="">4</option>
-			<option value='5' i18n:translate="">5</option>
-			<option value='6' i18n:translate="">6</option>
-			<option value='7' i18n:translate="">7</option>
-			<option value='8' i18n:translate="">8</option>
-			<option value='9' i18n:translate="">9</option>
-			<option value='10' i18n:translate="">10</option>
-		</select>
+                <span tal:replace="python:add_item"/>
+            </a>
+            <input name="ar_count"
+                   class="ar_count context_action_link"
+                   type="number"
+                   value="4"
+                   style="width:4em;border-radius:0;border:1px solid #ddd;padding:2px;"
+                   tal:condition="python:len(view.context_actions) > 0"/>
+            <a tal:attributes="
+				href python:view.context_actions[add_item]['url'];
+				class python:'context_action_link %s' % (view.context_actions[add_item].get('class',''))"
+               style="padding:5px 1px 3px 1px;"
+               tal:condition="python:len(view.context_actions) > 0">ARs
+            </a>
+        </tal:add_actions>
     </h1>
-	<script type="text/javascript">
+    <script type="text/javascript">
 	(function( $ ) {
 	$(document).ready(function(){
-		$('.ar_count').change(function(){
+		$('input.ar_count').change(function(){
 			url = $(".context_action_link").attr('href').split("?")[0];
 			$(".context_action_link").attr('href', url + "?ar_count="+$(this).val());
 		});
+		$('input.ar_count').click(function(e){e.preventDefault();})
+		$('input.ar_count').change();
 	});
 	}(jQuery));
-	</script>
+    </script>
 </metal:content-title>
 
 <metal:content-description fill-slot="content-description"

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,6 @@
 3.2.1 (unreleased)
 ------------------
-LIMS-2293: Add ui for editing ar_count in all analysisrequest lists
+LIMS-2299: Add ui for editing ar_count in all analysisrequest lists
 LIMS-2268: Instrument Interface. Vista Pro Simultaneous ICP, bi-directional CSV
 LIMS-2261: Cannot create analysis request
 LIMS-1562: Using a Sample Round. Basic form and printed form

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+LIMS-2293: Add ui for editing ar_count in all analysisrequest lists
 LIMS-2268: Instrument Interface. Vista Pro Simultaneous ICP, bi-directional CSV
 LIMS-2261: Cannot create analysis request
 LIMS-1562: Using a Sample Round. Basic form and printed form

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(name='bika.lims',
           'plone.app.relationfield',
           'plone.app.referenceablebehavior',
           'five.pt',
+          'z3c.jbot',
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
1) In order to be customised by extension packages using z3c.jbot, templates must be direct attributes of the class (with ViewPageTemplateFile).

2) When adding ARs, we always want to allow the ar_count to be set in the ui.  I changed the formatting and added the control as an input for manual entry.