### PR TITLE
LIMS-2319 AR Add: Deleting a selected CC Contact corrupts the UID of reference widgets.

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -727,8 +727,8 @@ function AnalysisRequestAddByCol() {
             var uid = $(this).attr('uid');
             var existing_uids = $('td[arnum="' + arnum + '"] input[name$="_uid"]').val().split(',');
             destroy(existing_uids, uid);
-            $('td[arnum="' + arnum + '"] input[name$="_uid"]').val(existing_uids.join(','));
-            $('td[arnum="' + arnum + '"] input[type="text"]').attr('uid', existing_uids.join(','));
+            $('td[arnum="' + arnum + '"] input[name$="CCContact-'+arnum+'_uid"]').val(existing_uids.join(','));
+            $('td[arnum="' + arnum + '"] input[name="CCContact-0"]').attr('uid', existing_uids.join(','));
             $(this).parent('div').remove();
         });
     }

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+LIMS-2319: AR Add: Deleting a selected CC Contact corrupts the UID of reference widgets.
 LIMS-2298: Add filter in Clients list
 LIMS-2268: Instrument Interface. Vista Pro Simultaneous ICP, bi-directional CSV
 LIMS-2261: Cannot create analysis request


### PR DESCRIPTION
Fixes LIMS-2319.  This is an old issue that I've fixed a few times now, without sending a PR.