### PR TITLE
Prevent adding None values when setting Sampletype/Samplepoint relation

### DIFF
--- a/bika/lims/content/samplepoint.py
+++ b/bika/lims/content/samplepoint.py
@@ -123,6 +123,10 @@ class SamplePoint(BaseContent, HistoryAwareMixin):
         added = value and [s for s in value if s not in existing] or []
         ret = self.Schema()['SampleTypes'].set(self, value)
 
+        # finally be sure that we aren't trying to set None values here.
+        removed = [x for x in removed if x]
+        added = [x for x in added if x]
+
         for st in removed:
             samplepoints = st.getSamplePoints()
             if self in samplepoints:

--- a/bika/lims/content/sampletype.py
+++ b/bika/lims/content/sampletype.py
@@ -163,6 +163,10 @@ class SampleType(BaseContent, HistoryAwareMixin):
         added = value and [s for s in value if s not in existing] or []
         ret = self.Schema()['SamplePoints'].set(self, value)
 
+        # finally be sure that we aren't trying to set None values here.
+        removed = [x for x in removed if x]
+        added = [x for x in added if x]
+
         for sp in removed:
             sampletypes = sp.getSampleTypes()
             if self in sampletypes:


### PR DESCRIPTION
Somehow this happens quite often, during various import scripts.  I guess there could be a neater way to fix it, but this works.