### PR TITLE
An error in initializeInstrumentsAndMethods:

### DIFF
--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -367,7 +367,10 @@ function WorksheetManageResultsView() {
         // we'll need them to retrieve all the IMM constraints/rules to be
         // applied later.
         var dictuids = $.parseJSON($('#lab_analyses #item_data, #analyses_form #item_data').val());
-        $.each(dictuids, function(key, value) { auids.push(key); });
+        // in AR manage_results, the above selector doesn't find #item_data.
+        if (dictuids){
+            $.each(dictuids, function(key, value) { auids.push(key); });
+        }
 
         // Retrieve all the rules/constraints to be applied for each analysis
         // by using an ajax call. The json dictionary returned is assigned to

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -366,11 +366,8 @@ function WorksheetManageResultsView() {
         /// Get all the analysis UIDs from this manage results table, cause
         // we'll need them to retrieve all the IMM constraints/rules to be
         // applied later.
-        var dictuids = $.parseJSON($('#lab_analyses #item_data, #analyses_form #item_data').val());
-        // in AR manage_results, the above selector doesn't find #item_data.
-        if (dictuids){
-            $.each(dictuids, function(key, value) { auids.push(key); });
-        }
+        var dictuids = $.parseJSON($('#item_data').val());
+        $.each(dictuids, function(key, value) { auids.push(key); });
 
         // Retrieve all the rules/constraints to be applied for each analysis
         // by using an ajax call. The json dictionary returned is assigned to

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+LIMS-2344: Fix some UI javascript failures when viewing ARs
 LIMS-2319: AR Add: Deleting a selected CC Contact corrupts the UID of reference widgets.
 LIMS-2325: Allow SampleTypes to be linked with Client Sample Points
 LIMS-2324: WS export to the LaChat Quick Chem FIA


### PR DESCRIPTION
The selector '#lab_analyses #item_data, #analyses_form #item_data' does not appear in AR manage_results tabs, and it's absence causes an error that stops JS processing in AR view/edit/manage_results forms.

@xispa I think the 'fix' I applied here may cause issues where this code is expected to work in AR context?

Please verify it!  Thanks.