### PR TITLE
Code Fix: SamplingDate is not assumed to be present

### DIFF
--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -1,8 +1,3 @@
-# This file is part of Bika LIMS
-#
-# Copyright 2011-2016 by it's authors.
-# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
-
 import json
 from bika.lims.utils.sample import create_sample
 from bika.lims.workflow import doActionFor

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -701,8 +701,9 @@ class AnalysisRequestsView(BikaListingView):
         val = obj.Schema().getField('SubGroup').get(obj)
         item['SubGroup'] = val.Title() if val else ''
 
-        samplingdate = obj.getSample().getSamplingDate()
-        item['SamplingDate'] = self.ulocalized_time(samplingdate, long_format=1)
+        sd = obj.getSample().getSamplingDate()
+        item['SamplingDate'] = \
+            self.ulocalized_time(sd, long_format=1) if sd else ''
         item['getDateReceived'] = self.ulocalized_time(obj.getDateReceived())
         item['getDatePublished'] = self.ulocalized_time(obj.getDatePublished())
         item['getDateVerified'] = getTransitionDate(obj, 'verify')
@@ -726,7 +727,7 @@ class AnalysisRequestsView(BikaListingView):
         if obj.getLate():
             after_icons += "<img src='%s/++resource++bika.lims.images/late.png' title='%s'>" % \
                 (self.portal_url, t(_("Late Analyses")))
-        if samplingdate > DateTime():
+        if sd and sd > DateTime():
             after_icons += "<img src='%s/++resource++bika.lims.images/calendar.png' title='%s'>" % \
                 (self.portal_url, t(_("Future dated sample")))
         if obj.getInvoiceExclude():
@@ -749,7 +750,7 @@ class AnalysisRequestsView(BikaListingView):
             item['ClientContact'] = ""
 
         SamplingWorkflowEnabled = sample.getSamplingWorkflowEnabled()
-        if SamplingWorkflowEnabled and not samplingdate > DateTime():
+        if SamplingWorkflowEnabled and sd and not sd > DateTime():
             datesampled = self.ulocalized_time(
                 sample.getDateSampled(), long_format=True)
             if not datesampled:
@@ -773,7 +774,8 @@ class AnalysisRequestsView(BikaListingView):
         state = self.workflow.getInfoFor(obj, 'review_state')
         if state == 'to_be_sampled' \
                 and checkPermission(SampleSample, obj) \
-                and not samplingdate > DateTime():
+                and sd \
+                and not sd > DateTime():
             item['required'] = ['getSampler', 'getDateSampled']
             item['allow_edit'] = ['getSampler', 'getDateSampled']
             samplers = getUsers(sample, ['Sampler', 'LabManager', 'Manager'])

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -750,7 +750,7 @@ class AnalysisRequestsView(BikaListingView):
             item['ClientContact'] = ""
 
         SamplingWorkflowEnabled = sample.getSamplingWorkflowEnabled()
-        if SamplingWorkflowEnabled and sd and not sd > DateTime():
+        if SamplingWorkflowEnabled and (not sd or not sd > DateTime()):
             datesampled = self.ulocalized_time(
                 sample.getDateSampled(), long_format=True)
             if not datesampled:
@@ -774,8 +774,7 @@ class AnalysisRequestsView(BikaListingView):
         state = self.workflow.getInfoFor(obj, 'review_state')
         if state == 'to_be_sampled' \
                 and checkPermission(SampleSample, obj) \
-                and sd \
-                and not sd > DateTime():
+                and (not sd or not sd > DateTime()):
             item['required'] = ['getSampler', 'getDateSampled']
             item['allow_edit'] = ['getSampler', 'getDateSampled']
             samplers = getUsers(sample, ['Sampler', 'LabManager', 'Manager'])

--- a/bika/lims/browser/reports/productivity_dailysamplesreceived.py
+++ b/bika/lims/browser/reports/productivity_dailysamplesreceived.py
@@ -57,6 +57,7 @@ class Report(BrowserView):
             analyses = sample.getAnalyses({})
             for analysis in analyses:
                 analysis = analysis.getObject()
+                sd = sample.getSamplingDate()
                 dataline = {'AnalysisKeyword': analysis.getKeyword(),
                             'AnalysisTitle': analysis.getServiceTitle(),
                             'SampleID': sample.getSampleID(),
@@ -64,7 +65,8 @@ class Report(BrowserView):
                             'SampleDateReceived': self.ulocalized_time(
                                 sample.getDateReceived(), long_format=1),
                             'SampleSamplingDate': self.ulocalized_time(
-                                sample.getSamplingDate(), long_format=1)}
+                                sd, long_format=1) if sd else ''
+                            }
                 datalines.append(dataline)
                 analyses_count += 1
 

--- a/bika/lims/browser/sample/printform.py
+++ b/bika/lims/browser/sample/printform.py
@@ -164,10 +164,8 @@ class SamplesPrint(BrowserView):
                 sampler_uid = 'no_sampler'
                 sampler_name = ''
             client_uid = sample.getClientUID()
-            date = \
-                self.ulocalized_time(
-                    sample.getSamplingDate(), long_format=0)\
-                if sample.getSamplingDate() else ''
+            sd = sample.getSamplingDate()
+            date = self.ulocalized_time(sd, long_format=0) if sd else ''
             # Getting the sampler filter result
             in_sampler_filter = self._filter_sampler == '' or\
                 sampler_uid == self._filter_sampler

--- a/bika/lims/browser/sample/view.py
+++ b/bika/lims/browser/sample/view.py
@@ -364,8 +364,7 @@ class SamplesView(BikaListingView):
         SamplingWorkflowEnabled =\
             self.context.bika_setup.getSamplingWorkflowEnabled()
 
-        if sd and not sd > DateTime() \
-                and SamplingWorkflowEnabled:
+        if SamplingWorkflowEnabled and (not sd or not sd > DateTime()):
             datesampled = self.ulocalized_time(
                 obj.getDateSampled(), long_format=True)
             if not datesampled:

--- a/bika/lims/browser/sample/view.py
+++ b/bika/lims/browser/sample/view.py
@@ -343,8 +343,9 @@ class SamplesView(BikaListingView):
 
         item['Created'] = self.ulocalized_time(obj.created())
 
-        samplingdate = obj.getSamplingDate()
-        item['SamplingDate'] = self.ulocalized_time(samplingdate, long_format=1)
+        sd = obj.getSamplingDate()
+        item['SamplingDate'] = \
+            self.ulocalized_time(sd, long_format=1) if sd else ''
 
         after_icons = ''
         if obj.getSampleType().getHazardous():
@@ -352,7 +353,7 @@ class SamplesView(BikaListingView):
                 "src='%s/++resource++bika.lims.images/hazardous.png'>" % \
                 (t(_("Hazardous")),
                  self.portal_url)
-        if obj.getSamplingDate() > DateTime():
+        if sd and sd > DateTime():
             after_icons += "<img title='%s' " \
                 "src='%s/++resource++bika.lims.images/calendar.png' >" % \
                 (t(_("Future dated sample")),
@@ -363,7 +364,7 @@ class SamplesView(BikaListingView):
         SamplingWorkflowEnabled =\
             self.context.bika_setup.getSamplingWorkflowEnabled()
 
-        if not samplingdate > DateTime() \
+        if sd and not sd > DateTime() \
                 and SamplingWorkflowEnabled:
             datesampled = self.ulocalized_time(
                 obj.getDateSampled(), long_format=True)

--- a/bika/lims/browser/templates/stickers/Code_128_1x48mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_128_1x48mm.pt
@@ -27,7 +27,8 @@
     sample_id         python:sample.getId();
     sample_point      python:sample.getSamplePoint() and sample.getSamplePoint().Title() or '';
     sample_type       python:sample.getSampleType().Title();
-    sampling_date     python:sample.getSamplingDate() and sample.getSamplingDate().Date();
+    sd                python:sample.getSamplingDate();
+    sampling_date     python:sd.Date() if sd else '';
     client_sample_id  python:sample.getClientSampleID();
     preservation      python:part.getPreservation() and part.getPreservation().Title() or '';
     container         python:part.getContainer() and part.getContainer().Title() or '';

--- a/bika/lims/browser/templates/stickers/Code_128_1x72mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_128_1x72mm.pt
@@ -34,7 +34,8 @@
     SamplePoint       python:sample.getSamplePoint() and sample.getSamplePoint().Title() or '';
     Preservation      python:part.getPreservation() and part.getPreservation().Title() or '';
     Container         python:part.getContainer() and part.getContainer().Title() or '';
-    SamplingDate      python:sample.getSamplingDate() and sample.getSamplingDate().Date();
+    sd                python:sample.getSamplingDate();
+    SamplingDate      python:sd.Date() if sd else '';
     Deviation         python:sample.getSamplingDeviation() and sample.getSamplingDeviation().Title() or '';
     DateSampled       python:sample.getDateSampled() and sample.getDateSampled().Date();
     Composite         python:sample.getComposite();

--- a/bika/lims/browser/templates/stickers/Code_39_1x54mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_39_1x54mm.pt
@@ -27,7 +27,8 @@
     sample_id         python:sample.getId();
     sample_point      python:sample.getSamplePoint() and sample.getSamplePoint().Title() or '';
     sample_type       python:sample.getSampleType().Title();
-    sampling_date     python:sample.getSamplingDate() and sample.getSamplingDate().Date();
+    sd                python:sample.getSamplingDate();
+    sampling_date     python:sd.Date() if sd else '';
     client_sample_id  python:sample.getClientSampleID();
     preservation      python:part.getPreservation() and part.getPreservation().Title() or '';
     container         python:part.getContainer() and part.getContainer().Title() or '';

--- a/bika/lims/browser/templates/stickers/Code_39_1x72mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_39_1x72mm.pt
@@ -34,7 +34,8 @@
     SamplePoint       python:sample.getSamplePoint() and sample.getSamplePoint().Title() or '';
     Preservation      python:part.getPreservation() and part.getPreservation().Title() or '';
     Container         python:part.getContainer() and part.getContainer().Title() or '';
-    SamplingDate      python:sample.getSamplingDate() and sample.getSamplingDate().Date();
+    sd                python:sample.getSamplingDate();
+    SamplingDate      python:sd.Date() if sd else '';
     Deviation         python:sample.getSamplingDeviation() and sample.getSamplingDeviation().Title() or '';
     DateSampled       python:sample.getDateSampled() and sample.getDateSampled().Date();
     Composite         python:sample.getComposite();

--- a/bika/lims/browser/templates/stickers/Code_93_2dx38mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_93_2dx38mm.pt
@@ -34,7 +34,8 @@
     sample_id         python:sample.getId();
     sample_point      python:sample.getSamplePoint() and sample.getSamplePoint().Title() or '';
     sample_type       python:sample.getSampleType().Title();
-    sampling_date     python:sample.getSamplingDate() and sample.getSamplingDate().Date();
+    sd                python:sample.getSamplingDate();
+    sampling_date      python:sd.Date() if sd else '';
     client_sample_id  python:sample.getClientSampleID();
     preservation      python:part.getPreservation() and part.getPreservation().Title() or '';
     container         python:part.getContainer() and part.getContainer().Title() or '';

--- a/bika/lims/browser/templates/stickers/Code_93_2x38mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_93_2x38mm.pt
@@ -34,7 +34,8 @@
     sample_id         python:sample.getId();
     sample_point      python:sample.getSamplePoint() and sample.getSamplePoint().Title() or '';
     sample_type       python:sample.getSampleType().Title();
-    sampling_date     python:sample.getSamplingDate() and sample.getSamplingDate().Date();
+    sd                python:sample.getSamplingDate();
+    sampling_date      python:sd.Date() if sd else '';
     client_sample_id  python:sample.getClientSampleID();
     preservation      python:part.getPreservation() and part.getPreservation().Title() or '';
     container         python:part.getContainer() and part.getContainer().Title() or '';

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2589,14 +2589,16 @@ class AnalysisRequest(BaseFolder):
         if skip(self, "sampling_workflow"):
             return
         sample = self.getSample()
-        if sample.getSamplingDate() > DateTime():
+        sd = sample.getSamplingDate()
+        if sd and sd > DateTime():
             sample.future_dated = True
 
     def workflow_script_no_sampling_workflow(self):
         if skip(self, "no_sampling_workflow"):
             return
         sample = self.getSample()
-        if sample.getSamplingDate() > DateTime():
+        sd = sample.getSamplingDate()
+        if sd and sd > DateTime():
             sample.future_dated = True
 
     def workflow_script_attach(self):


### PR DESCRIPTION
Never assume that SamplingDate has a value, always check for None before using the field!
 
This is needed for client packages which hide and/or un-require the SamplingDate field.  in future SamplingDate will conditionally become unrequired/invisible in bika.lims too, this PR will be necessary at that time, also.