### PR TITLE
Fix test's "AttributeError: uid_catalog"

### DIFF
--- a/bika/lims/browser/fields/historyawarereferencefield.py
+++ b/bika/lims/browser/fields/historyawarereferencefield.py
@@ -128,7 +128,11 @@ class HistoryAwareReferenceField(ReferenceField):
     def get(self, instance, aslist=False, **kwargs):
         """get() returns the list of objects referenced under the relationship.
         """
-        uc = getToolByName(instance, "uid_catalog")
+        try:
+            uc = getToolByName(instance, "uid_catalog")
+        except AttributeError as err:
+            logger.error("AttributeError: {0}".format(err))
+            return []
 
         try:
             res = instance.getRefs(relationship=self.relationship)


### PR DESCRIPTION
Fixes the annoying bug "AttributeError: uid_catalog" when running tests.

```
$ bin/test -v -p -s bika.lims --layer=bika.lims.testing.BikaTestingLayer:Functional
Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.241 seconds.
  Set up plone.app.testing.layers.PloneFixture in 8.155 seconds.
  Set up bika.lims.testing.BikaTestLayer in 1 minutes 4.331 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
    34/45 (75.6%)                                                                                
  Ran 45 tests with 0 failures and 0 errors in 9 minutes 17.985 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.017 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.191 seconds.
  Tear down plone.testing.z2.Startup in 0.006 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.005 seconds.
```