### PR TITLE
Lims 2436: ar templates do not fire on ar create when title is an integer

### DIFF
--- a/bika/lims/exportimport/setupdata/__init__.py
+++ b/bika/lims/exportimport/setupdata/__init__.py
@@ -1801,7 +1801,7 @@ class AR_Templates(WorksheetImporter):
 
             obj = _createObjectByType("ARTemplate", folder, tmpID())
             obj.edit(
-                title=row['title'],
+                title=str(row['title']),
                 description=row.get('description', ''),
                 Remarks=row.get('Remarks', ''),
                 ReportDryMatter=bool(row['ReportDryMatter']))

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -259,7 +259,7 @@ def sortable_title(portal, title):
         return ''
 
     def_charset = portal.plone_utils.getSiteEncoding()
-    sortabletitle = title.lower().strip()
+    sortabletitle = str(title.lower().strip())
     # Replace numbers with zero filled numbers
     sortabletitle = num_sort_regex.sub(zero_fill, sortabletitle)
     # Truncate to prevent bloat


### PR DESCRIPTION
AR Templates with titles that are not strings end up with empty sortable title and Title fields in the bika_setup_catalog and subsequently are not present in the list of templates available during AR creation.