### PR TITLE
error with plone protect

### DIFF
--- a/bika/lims/tests/base.py
+++ b/bika/lims/tests/base.py
@@ -23,6 +23,7 @@ from Testing.ZopeTestCase.functional import Functional
 from zope.component import getSiteManager
 
 import unittest
+import plone.protect.auto
 
 
 class MockMailHost(_MMH):
@@ -40,6 +41,11 @@ class BikaTestCase(unittest.TestCase):
 
     def setUp(self):
         super(BikaTestCase, self).setUp()
+        # Some browser paths like ""?analysisrequests_review_state=cancelled"
+        # do not work because plone.protect protect them.
+        # Disable the plone.protect on the testing layer
+        self.CSRF_DISABLED_ORIGINAL = plone.protect.auto.CSRF_DISABLED
+        plone.protect.auto.CSRF_DISABLED = True
 
     def afterSetUp(self):
         self.portal._original_MailHost = self.portal.MailHost
@@ -51,6 +57,10 @@ class BikaTestCase(unittest.TestCase):
         self.portal.email_from_address = 'test@example.com'
         ltool = self.portal.portal_languages
         ltool.setLanguageBindings()
+
+    def tearDown(self):
+        # Reset the plone.protect on the testing layer
+        plone.protect.auto.CSRF_DISABLED = self.CSRF_DISABLED_ORIGINAL
 
     def beforeTearDown(self):
         self.portal.MailHost = self.portal._original_MailHost

--- a/bika/lims/tests/test_LIMS-2062-cancelled-ars-visible-in-lists.py
+++ b/bika/lims/tests/test_LIMS-2062-cancelled-ars-visible-in-lists.py
@@ -12,6 +12,7 @@ from bika.lims.utils import tmpID
 from DateTime.DateTime import DateTime
 from plone.app.testing import login, logout
 from plone.app.testing import TEST_USER_NAME
+import plone.protect.auto
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
 
@@ -55,8 +56,7 @@ class Test_ShowPrices(BikaFunctionalTestCase):
         transaction.commit()
 
     def tearDown(self):
-        super(Test_ShowPrices, self).setUp()
-        login(self.portal, TEST_USER_NAME)
+        super(Test_ShowPrices, self).tearDown()
 
     def test_default_view_does_not_show_cancelled_items(self):
         url = self.portal.analysisrequests.absolute_url()


### PR DESCRIPTION
Some browser paths like ""?analysisrequests_review_state=cancelled" do not work because plone.protect protect them.
