### PR TITLE
Add option to allow labman to self-verify analysis results

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -733,8 +733,14 @@ class AnalysesView(BikaListingView):
                                                   username=username)
                 if allowed and not obj.isUserAllowedToVerify(member):
                     after_icons.append(
-                         "<img src='++resource++bika.lims.images/submitted-by-current-user.png' title='%s'/>" %
-                         (t(_("Cannot verify: Submitted by current user")))
+                        "<img src='++resource++bika.lims.images/submitted-by-current-user.png' title='%s'/>" %
+                        (t(_("Cannot verify: Submitted by current user")))
+                        )
+                elif allowed:
+                    if obj.getSubmittedBy() == member.getUser().getId():
+                        after_icons.append(
+                        "<img src='++resource++bika.lims.images/warning.png' title='%s'/>" %
+                        (t(_("Can be verified, but submitted by current user")))
                         )
 
             # add icon for assigned analyses in AR views

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -5,6 +5,7 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
+from plone import api
 from AccessControl import getSecurityManager
 from Products.CMFPlone.utils import safe_unicode
 from bika.lims import bikaMessageFactory as _
@@ -15,6 +16,7 @@ from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import QCANALYSIS_TYPES
 from bika.lims.interfaces import IResultOutOfRange
 from bika.lims.permissions import *
+from bika.lims.permissions import Verify as VerifyPermission
 from bika.lims.utils import isActive
 from bika.lims.utils import getUsers
 from bika.lims.utils import to_utf8
@@ -295,6 +297,8 @@ class AnalysesView(BikaListingView):
 
         self.categories = []
         items = super(AnalysesView, self).folderitems(full_objects = True)
+
+        member = mtool.getAuthenticatedMember()
 
         # manually skim retracted analyses from the list
         new_items = []
@@ -720,25 +724,18 @@ class AnalysesView(BikaListingView):
                          self.portal_url,
                          t(_("Late Analysis")))
 
-            # Submitting user may not verify results (admin can though)
-            if items[i]['review_state'] == 'to_be_verified' and \
-               not checkPermission(VerifyOwnResults, obj):
-                user_id = getSecurityManager().getUser().getId()
-                self_submitted = False
-                try:
-                    review_history = list(workflow.getInfoFor(obj, 'review_history'))
-                    review_history.reverse()
-                    for event in review_history:
-                        if event.get('action') == 'submit':
-                            if event.get('actor') == user_id:
-                                self_submitted = True
-                            break
-                    if self_submitted:
-                        items[i]['after']['state_title'] = \
-                             "<img src='++resource++bika.lims.images/submitted-by-current-user.png' title='%s'/>" % \
-                             (t(_("Cannot verify: Submitted by current user")))
-                except WorkflowException:
-                    pass
+            after_icons = []
+            # Submitting user may not verify results unless the user is labman
+            # or manager and the AS has isSelfVerificationEnabled set to True
+            if items[i]['review_state'] == 'to_be_verified':
+                username = member.getUserName()
+                allowed = api.user.has_permission(VerifyPermission,
+                                                  username=username)
+                if allowed and not obj.isUserAllowedToVerify(member):
+                    after_icons.append(
+                         "<img src='++resource++bika.lims.images/submitted-by-current-user.png' title='%s'/>" %
+                         (t(_("Cannot verify: Submitted by current user")))
+                        )
 
             # add icon for assigned analyses in AR views
             if self.context.portal_type == 'AnalysisRequest':
@@ -749,11 +746,12 @@ class AnalysesView(BikaListingView):
                     br = obj.getBackReferences('WorksheetAnalysis')
                     if len(br) > 0:
                         ws = br[0]
-                        items[i]['after']['state_title'] = \
-                             "<a href='%s'><img src='++resource++bika.lims.images/worksheet.png' title='%s'/></a>" % \
-                             (ws.absolute_url(),
-                              t(_("Assigned to: ${worksheet_id}",
-                                  mapping={'worksheet_id': safe_unicode(ws.id)})))
+                        after_icons.append("<a href='%s'><img src='++resource++bika.lims.images/worksheet.png' title='%s'/></a>" %
+                        (ws.absolute_url(),
+                         t(_("Assigned to: ${worksheet_id}",
+                             mapping={'worksheet_id': safe_unicode(ws.id)}))))
+            items[i]['after']['state_title'] = '&nbsp;'.join(after_icons)
+
 
         # the TAL requires values for all interim fields on all
         # items, so we set blank values in unused cells

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -3,6 +3,7 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
+from plone import api
 from AccessControl import getSecurityManager
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -12,6 +13,7 @@ from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.utils import getUsers
 from bika.lims.workflow import getTransitionDate
 from bika.lims.permissions import *
+from bika.lims.permissions import Verify as VerifyPermission
 from bika.lims.utils import to_utf8, getUsers
 from DateTime import DateTime
 from Products.Archetypes import PloneMessageFactory as PMF
@@ -844,23 +846,14 @@ class AnalysisRequestsView(BikaListingView):
             item['class']['getDatePreserved'] = 'provisional'
 
         # Submitting user may not verify results
-        if item['review_state'] == 'to_be_verified' and \
-           not checkPermission(VerifyOwnResults, obj):
-            self_submitted = False
-            try:
-                review_history = list(self.workflow.getInfoFor(obj, 'review_history'))
-                review_history.reverse()
-                for event in review_history:
-                    if event.get('action') == 'submit':
-                        if event.get('actor') == member.getId():
-                            self_submitted = True
-                        break
-                if self_submitted:
-                    item['after']['state_title'] = \
-                         "<img src='++resource++bika.lims.images/submitted-by-current-user.png' title='%s'/>" % \
-                         t(_("Cannot verify: Submitted by current user"))
-            except Exception:
-                pass
+        if item['review_state'] == 'to_be_verified':
+            username = member.getUserName()
+            allowed = api.user.has_permission(VerifyPermission,
+                                              username=username)
+            if allowed and not obj.isUserAllowedToVerify(member):
+                item['after']['state_title'] = \
+                     "<img src='++resource++bika.lims.images/submitted-by-current-user.png' title='%s'/>" % \
+                     t(_("Cannot verify: Submitted by current user"))
 
         return item
 

--- a/bika/lims/browser/worksheet/workflow.py
+++ b/bika/lims/browser/worksheet/workflow.py
@@ -148,7 +148,7 @@ class WorksheetWorkflowAction(WorkflowAction):
             # default bika_listing.py/WorkflowAction, but then go to view screen.
             self.destination_url = self.context.absolute_url()
             return self.workflow_action_default(action='verify',
-                                                came_from='edit')
+                                                came_from=came_from)
         else:
             # default bika_listing.py/WorkflowAction for other transitions
             WorkflowAction.__call__(self)

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -8,6 +8,7 @@
 
 "DuplicateAnalysis uses this as it's base.  This accounts for much confusion."
 
+from plone import api
 from AccessControl import getSecurityManager
 from AccessControl import ClassSecurityInfo
 from DateTime import DateTime
@@ -32,6 +33,7 @@ from bika.lims.browser.fields import DurationField
 from bika.lims.browser.fields import HistoryAwareReferenceField
 from bika.lims.browser.fields import InterimFieldsField
 from bika.lims.permissions import *
+from bika.lims.permissions import Verify as VerifyPermission
 from bika.lims.browser.widgets import DurationWidget
 from bika.lims.browser.widgets import RecordsWidget as BikaRecordsWidget
 from bika.lims.config import PROJECTNAME
@@ -1000,6 +1002,79 @@ class Analysis(BaseContent):
         else:
             return ''
 
+    def isVerifiable(self):
+        """
+        Checks it the current analysis can be verified. This is, its not a
+        cancelled analysis and has no dependenant analyses not yet verified
+        :return: True or False
+        """
+        # Check if the analysis is active
+        workflow = getToolByName(self, "portal_workflow")
+        objstate = workflow.getInfoFor(self, 'cancellation_state', 'active')
+        if objstate == "cancelled":
+            return False
+
+        # Check if the analysis state is to_be_verified
+        review_state = workflow.getInfoFor(self, "review_state")
+        if review_state != 'to_be_verified':
+            return False
+
+        # Check if the analysis has dependencies not yet verified
+        for d in self.getDependencies():
+            review_state = workflow.getInfoFor(d, "review_state")
+            if review_state in (
+                    "to_be_sampled", "to_be_preserved", "sample_due",
+                    "sample_received", "attachment_due", "to_be_verified"):
+                return False
+
+        # All checks passsed
+        return True
+
+    def isUserAllowedToVerify(self, member):
+        """
+        Checks if the specified user has enough privileges to verify the
+        current analysis. Apart of roles, the function also checks if the
+        option IsSelfVerificationEnabled is set to true at Service or
+        Bika Setup levels and validates if according to this value, together
+        with the user roles, the analysis can be verified. Note that this
+        function only returns if the user can verify the analysis, but not if
+        the analysis is ready to be verified (see isVerifiable)
+        :member: user to be tested
+        :return: true or false
+        """
+        # Check if the user has "Bika: Verify" privileges
+        username = member.getUserName()
+        allowed = api.user.has_permission(VerifyPermission, username=username)
+        if not allowed:
+            return False
+
+        # Check if the user who submited the result is the same as the current
+        workflow = getToolByName(self, "portal_workflow")
+        user_id = member.getUser().getId()
+        self_submitted = False
+        try:
+            review_history = workflow.getInfoFor(self, "review_history")
+            review_history = self.reverseList(review_history)
+            for event in review_history:
+                if event.get("action") == "submit":
+                    self_submitted = event.get("actor") == user_id
+                    break
+        except WorkflowException:
+            # https://jira.bikalabs.com/browse/LIMS-2037;
+            # Sometimes the workflow history is inexplicably missing!
+            # Let's assume the user that submitted the result is not the same
+            # as the current logged user
+            self_submitted = False
+
+        # The submitter and the user must be different unless the analysis has
+        # the option SelfVerificationEnabled set to true
+        selfverification = self.getService().isSelfVerificationEnabled()
+        if self_submitted and not selfverification:
+            return False
+
+        # All checks pass
+        return True
+
     def guard_sample_transition(self):
         workflow = getToolByName(self, "portal_workflow")
         if workflow.getInfoFor(self, "cancellation_state", "active") == "cancelled":
@@ -1049,58 +1124,20 @@ class Analysis(BaseContent):
         return True
 
     def guard_verify_transition(self):
+        """
+        Checks if the verify transition can be performed to the current
+        Analysis by the current user depending on the user roles, as
+        well as the status of the analysis
+        :return: true or false
+        """
         mtool = getToolByName(self, "portal_membership")
         checkPermission = mtool.checkPermission
-        workflow = getToolByName(self, "portal_workflow")
-        objstate = workflow.getInfoFor(self, 'cancellation_state', 'active')
-        if objstate == "cancelled":
-            return False
-
-        # Only Analysis needs to have dependencies checked
-        if self.portal_type == "Analysis":
-            for d in self.getDependencies():
-                review_state = workflow.getInfoFor(d, "review_state")
-                if review_state in (
-                        "to_be_sampled", "to_be_preserved", "sample_due",
-                        "sample_received", "attachment_due", "to_be_verified"):
-                    return False
-        else:
-            # This is not an analysis!
-            logger.warn("portal type: %s" % self.portal_type)
-            return False
-
-        # Check if the current has the LabManager role
-        member = mtool.getAuthenticatedMember()
-        allowed_roles = ['LabManager', 'Manager']
-        allowed = [r for r in member.getRoles() if r in allowed_roles]
-        if not allowed:
-            return False
-
-        # Check if the user who submited the result is the same as the current
-        user_id = getSecurityManager().getUser().getId()
-        self_submitted = False
-        try:
-            review_history = workflow.getInfoFor(self, "review_history")
-            review_history = self.reverseList(review_history)
-            for event in review_history:
-                if event.get("action") == "submit":
-                    self_submitted = event.get("actor") == user_id
-                    break
-        except WorkflowException:
-            # https://jira.bikalabs.com/browse/LIMS-2037;
-            # Sometimes the workflow history is inexplicably missing!
-            # Let's assume the user that submitted the result is not the same
-            # as the current logged user
-            self_submitted = False
-
-        # The submitter and the user must be different unless the analysis has
-        # the option SelfVerificationEnabled set to true
-        selfverification = self.getService().isSelfVerificationEnabled()
-        if self_submitted and not selfverification:
-            return False
-
-        # All checks passed. Allow to verify
-        return True
+        # Check if the analysis is in a "verifiable" state
+        if self.isVerifiable():
+            # Check if the user can verify the analysis
+            member = mtool.getAuthenticatedMember()
+            return self.isUserAllowedToVerify(member)
+        return False
 
     def guard_assign_transition(self):
         workflow = getToolByName(self, "portal_workflow")

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -5,6 +5,7 @@
 
 """The request for analysis by a client. It contains analysis instances.
 """
+from plone import api
 import logging
 from AccessControl import ClassSecurityInfo
 from DateTime import DateTime
@@ -23,6 +24,7 @@ from Products.CMFPlone.utils import _createObjectByType
 from bika.lims.browser.fields import ARAnalysesField
 from bika.lims.config import PROJECTNAME
 from bika.lims.permissions import *
+from bika.lims.permissions import Verify as VerifyPermission
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IAnalysisRequest, ISamplePrepWorkflow
 from bika.lims.browser.fields import HistoryAwareReferenceField
@@ -2579,6 +2581,88 @@ class AnalysisRequest(BaseFolder):
             actor = items.get('actor')
             return mtool.getMemberById(actor)
         return None
+
+    def isVerifiable(self):
+        """
+        Checks it the current Analysis Request can be verified. This is, its
+        not a cancelled Analysis Request and all the analyses that contains
+        are verifiable too. Note that verifying an Analysis Request is in fact,
+        the same as verifying all the analyses that contains. Therefore, the
+        'verified' state of an Analysis Request shouldn't be a 'real' state,
+        rather a kind-of computed state, based on the statuses of the analyses
+        it contains. This is why this function checks if the analyses
+        contained are verifiable, cause otherwise, the Analysis Request will
+        never be able to reach a 'verified' state.
+        :return: True or False
+        """
+        # Check if the analysis request is active
+        workflow = getToolByName(self, "portal_workflow")
+        objstate = workflow.getInfoFor(self, 'cancellation_state', 'active')
+        if objstate == "cancelled":
+            return False
+
+        # Check if the analysis request state is to_be_verified
+        review_state = workflow.getInfoFor(self, "review_state")
+        if review_state == 'to_be_verified':
+            # This means that all the analyses from this analysis request have
+            # already been transitioned to a 'verified' state, and so the
+            # analysis request itself
+            return True
+        else:
+            # Check if the analyses contained in this analysis request are
+            # verifiable. Only check those analyses not cancelled and that
+            # are not in a kind-of already verified state
+            canbeverified = True
+            omit = ['published', 'retracted', 'rejected', 'verified']
+            for a in self.getAnalyses(full_objects=True):
+                st = workflow.getInfoFor(a, 'cancellation_state', 'active')
+                if st == 'cancelled':
+                    continue
+                st = workflow.getInfoFor(a, 'review_state')
+                if st in omit:
+                    continue
+                # Can the analysis be verified?
+                if not a.isVerifiable(self):
+                    canbeverified = False
+                    break
+            return canbeverified
+
+    def isUserAllowedToVerify(self, member):
+        """
+        Checks if the specified user has enough privileges to verify the
+        current AR. Apart from the roles, this function also checks if the
+        current user has enough privileges to verify all the analyses contained
+        in this Analysis Request. Note that this function only returns if the
+        user can verify the analysis request according to his/her privileges
+        and the analyses contained (see isVerifiable function)
+        :member: user to be tested
+        :return: true or false
+        """
+        # Check if the user has "Bika: Verify" privileges
+        username = member.getUserName()
+        allowed = api.user.has_permission(VerifyPermission, username=username)
+        if not allowed:
+            return False
+        # Check if the user is allowed to verify all the contained analyses
+        notallowed = [a for a in self.getAnalyses(full_objects=True)
+                      if not a.isUserAllowedToVerify(member)]
+        return not notallowed
+
+    def guard_verify_transition(self):
+        """
+        Checks if the verify transition can be performed to the current
+        Analysis Request by the current user depending on the user roles, as
+        well as the statuses of the analyses assigned to this Analysis Request
+        :return: true or false
+        """
+        mtool = getToolByName(self, "portal_membership")
+        checkPermission = mtool.checkPermission
+        # Check if the Analysis Request is in a "verifiable" state
+        if self.isVerifiable():
+            # Check if the user can verify the Analysis Request
+            member = mtool.getAuthenticatedMember()
+            return self.isUserAllowedToVerify(member)
+        return False
 
     def guard_unassign_transition(self):
         """Allow or disallow transition depending on our children's states

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -956,7 +956,7 @@ schema = BikaSchema.copy() + Schema((
                  ),
     ),
     BooleanField(
-        'SelfVerification',
+        'SelfVerificationEnabled',
         schemata="Analysis",
         default=False,
         widget=BooleanWidget(
@@ -965,7 +965,8 @@ schema = BikaSchema.copy() + Schema((
                 "If enabled, the same user who submitted a result "
                 "for this analysis will be able to verify it. Note "
                 "only Lab Managers can verify results. Disabled by "
-                "default. "),
+                "default. The option set here has priority over the "
+                "option set in Bika Setup"),
          ),
     ),
     StringField('CommercialID',

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -955,6 +955,19 @@ schema = BikaSchema.copy() + Schema((
                         "Profile and/or Analysis Request"),
                  ),
     ),
+    BooleanField(
+        'SelfVerification',
+        schemata="Analysis",
+        default=False,
+        widget=BooleanWidget(
+            label=_("Allow self-verification of results"),
+            description=_(
+                "If enabled, the same user who submitted a result "
+                "for this analysis will be able to verify it. Note "
+                "only Lab Managers can verify results. Disabled by "
+                "default. "),
+         ),
+    ),
     StringField('CommercialID',
         searchable=1,
         schemata='Description',

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -1393,7 +1393,7 @@ class AnalysisService(BaseContent, HistoryAwareMixin):
         items.sort(lambda x, y: cmp(x[1], y[1]))
         return DisplayList(list(items))
 
-    def getSelfVerificationEnabled(self):
+    def isSelfVerificationEnabled(self):
         """
         Returns if the user that submitted a result for this analysis must also
         be able to verify the result

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -955,18 +955,19 @@ schema = BikaSchema.copy() + Schema((
                         "Profile and/or Analysis Request"),
                  ),
     ),
-    BooleanField(
-        'SelfVerificationEnabled',
+    IntegerField(
+        'SelfVerification',
         schemata="Analysis",
-        default=False,
-        widget=BooleanWidget(
-            label=_("Allow self-verification of results"),
+        default=-1,
+        vocabulary="_getSelfVerificationVocabulary",
+        widget=SelectionWidget(
+            label=_("Self-verification of results"),
             description=_(
-                "If enabled, the same user who submitted a result "
-                "for this analysis will be able to verify it. Note "
-                "only Lab Managers can verify results. Disabled by "
-                "default. The option set here has priority over the "
-                "option set in Bika Setup"),
+                "If enabled, the same user who submitted a result for this "
+                "analysis will be able to verify it. Note only Lab Managers "
+                "can verify results. The option set here has priority over "
+                "the option set in Bika Setup"),
+            format="select",
          ),
     ),
     StringField('CommercialID',
@@ -1390,6 +1391,29 @@ class AnalysisService(BaseContent, HistoryAwareMixin):
         items = [(o.UID, o.Title) for o in
                  bsc(portal_type='Preservation', inactive_state='active')]
         items.sort(lambda x, y: cmp(x[1], y[1]))
+        return DisplayList(list(items))
+
+    def getSelfVerificationEnabled(self):
+        """
+        Returns if the user that submitted a result for this analysis must also
+        be able to verify the result
+        :return: true or false
+        """
+        bsve = self.bika_setup.getSelfVerificationEnabled()
+        vs = self.getSelfVerification()
+        return bsve if vs == -1 else vs == 1
+
+    def _getSelfVerificationVocabulary(self):
+        """
+        Returns a DisplayList with the available options for the
+        self-verification list: 'system default', 'true', 'false'
+        :return: DisplayList with the available options for the
+            self-verification list
+        """
+        bsve = self.bika_setup.getSelfVerificationEnabled()
+        bsve = _('Yes') if bsve else _('No')
+        bsval = "%s (%s)" % (_("System default"), bsve)
+        items = [('-1', bsval), ('0', _('No')), ('1', _('Yes'))]
         return DisplayList(list(items))
 
     def workflow_script_activate(self):

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -342,7 +342,7 @@ schema = BikaFolderSchema.copy() + Schema((
     ),
     BooleanField(
         'SelfVerificationEnabled',
-        schemata="Analysis",
+        schemata="Analyses",
         default=False,
         widget=BooleanWidget(
             label=_("Allow self-verification of results"),

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -334,7 +334,24 @@ schema = BikaFolderSchema.copy() + Schema((
         default = False,
         widget = BooleanWidget(
             label=_("Add a remarks field to all analyses"),
+            description=_(
+                "If enabled, a free text field will be displayed close to "
+                "each analysis in results entry view"
+            )
         ),
+    ),
+    BooleanField(
+        'SelfVerificationEnabled',
+        schemata="Analysis",
+        default=False,
+        widget=BooleanWidget(
+            label=_("Allow self-verification of results"),
+            description=_(
+                "If enabled, the same user who submitted a result "
+                "for this analysis will be able to verify it. Note "
+                "only Lab Managers can verify results. Disabled by "
+                "default"),
+         ),
     ),
     ReferenceField('DryMatterService',
         schemata = "Analyses",

--- a/bika/lims/content/referenceanalysis.py
+++ b/bika/lims/content/referenceanalysis.py
@@ -8,6 +8,7 @@
 
 """ReferenceAnalysis
 """
+from plone import api
 from AccessControl import ClassSecurityInfo
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t, formatDecimalMark
@@ -18,6 +19,7 @@ from bika.lims.browser.widgets import RecordsWidget as BikaRecordsWidget
 from bika.lims.config import STD_TYPES, PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IReferenceAnalysis
+from bika.lims.permissions import Verify as VerifyPermission
 from bika.lims.subscribers import skip
 from bika.lims.utils.analysis import get_significant_digits
 from DateTime import DateTime
@@ -377,6 +379,95 @@ class ReferenceAnalysis(BaseContent):
             return get_significant_digits(uncertainty)
         else:
             return serv.getPrecision(result)
+
+    def isVerifiable(self):
+        """
+        Checks it the current analysis can be verified. This is, its not a
+        cancelled analysis and has no dependenant analyses not yet verified
+        :return: True or False
+        """
+        # Check if the analysis is active
+        workflow = getToolByName(self, "portal_workflow")
+        objstate = workflow.getInfoFor(self, 'cancellation_state', 'active')
+        if objstate == "cancelled":
+            return False
+
+        # Check if the analysis state is to_be_verified
+        review_state = workflow.getInfoFor(self, "review_state")
+        if review_state != 'to_be_verified':
+            return False
+
+        # Check if the analysis has dependencies not yet verified
+        for d in self.getDependencies():
+            review_state = workflow.getInfoFor(d, "review_state")
+            if review_state in (
+                    "to_be_sampled", "to_be_preserved", "sample_due",
+                    "sample_received", "attachment_due", "to_be_verified"):
+                return False
+
+        # All checks passsed
+        return True
+
+    def isUserAllowedToVerify(self, member):
+        """
+        Checks if the specified user has enough privileges to verify the
+        current analysis. Apart of roles, the function also checks if the
+        option IsSelfVerificationEnabled is set to true at Service or
+        Bika Setup levels and validates if according to this value, together
+        with the user roles, the analysis can be verified. Note that this
+        function only returns if the user can verify the analysis, but not if
+        the analysis is ready to be verified (see isVerifiable)
+        :member: user to be tested
+        :return: true or false
+        """
+        # Check if the user has "Bika: Verify" privileges
+        username = member.getUserName()
+        allowed = api.user.has_permission(VerifyPermission, username=username)
+        if not allowed:
+            return False
+
+        # Check if the user who submited the result is the same as the current
+        workflow = getToolByName(self, "portal_workflow")
+        user_id = member.getUser().getId()
+        self_submitted = False
+        try:
+            review_history = workflow.getInfoFor(self, "review_history")
+            review_history = self.reverseList(review_history)
+            for event in review_history:
+                if event.get("action") == "submit":
+                    self_submitted = event.get("actor") == user_id
+                    break
+        except WorkflowException:
+            # https://jira.bikalabs.com/browse/LIMS-2037;
+            # Sometimes the workflow history is inexplicably missing!
+            # Let's assume the user that submitted the result is not the same
+            # as the current logged user
+            self_submitted = False
+
+        # The submitter and the user must be different unless the analysis has
+        # the option SelfVerificationEnabled set to true
+        selfverification = self.getService().isSelfVerificationEnabled()
+        if self_submitted and not selfverification:
+            return False
+
+        # All checks pass
+        return True
+
+    def guard_verify_transition(self):
+        """
+        Checks if the verify transition can be performed to the current
+        Analysis by the current user depending on the user roles, as
+        well as the status of the analysis
+        :return: true or false
+        """
+        mtool = getToolByName(self, "portal_membership")
+        checkPermission = mtool.checkPermission
+        # Check if the analysis is in a "verifiable" state
+        if self.isVerifiable():
+            # Check if the user can verify the analysis
+            member = mtool.getAuthenticatedMember()
+            return self.isUserAllowedToVerify(member)
+        return False
 
     def workflow_script_submit(self):
         if skip(self, "submit"):

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -3,6 +3,7 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
+from plone import api
 from AccessControl import ClassSecurityInfo
 from bika.lims import bikaMessageFactory as _, logger
 from bika.lims.config import *
@@ -14,6 +15,7 @@ from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IWorksheet
 from bika.lims.permissions import EditWorksheet, ManageWorksheets
+from bika.lims.permissions import Verify as VerifyPermission
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import skip
 from DateTime import DateTime
@@ -598,6 +600,88 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             return analyst_member.getProperty('fullname')
         else:
             return analyst
+
+    def isVerifiable(self):
+        """
+        Checks it the current Worksheet can be verified. This is, its
+        not a cancelled Worksheet and all the analyses that contains
+        are verifiable too. Note that verifying a Worksheet is in fact,
+        the same as verifying all the analyses that contains. Therefore, the
+        'verified' state of a Worksheet shouldn't be a 'real' state,
+        rather a kind-of computed state, based on the statuses of the analyses
+        it contains. This is why this function checks if the analyses
+        contained are verifiable, cause otherwise, the Worksheet will
+        never be able to reach a 'verified' state.
+        :return: True or False
+        """
+        # Check if the worksheet is active
+        workflow = getToolByName(self, "portal_workflow")
+        objstate = workflow.getInfoFor(self, 'cancellation_state', 'active')
+        if objstate == "cancelled":
+            return False
+
+        # Check if the worksheet state is to_be_verified
+        review_state = workflow.getInfoFor(self, "review_state")
+        if review_state == 'to_be_verified':
+            # This means that all the analyses from this worksheet have
+            # already been transitioned to a 'verified' state, and so the
+            # woksheet itself
+            return True
+        else:
+            # Check if the analyses contained in this worksheet are
+            # verifiable. Only check those analyses not cancelled and that
+            # are not in a kind-of already verified state
+            canbeverified = True
+            omit = ['published', 'retracted', 'rejected', 'verified']
+            for a in self.getAnalyses():
+                st = workflow.getInfoFor(a, 'cancellation_state', 'active')
+                if st == 'cancelled':
+                    continue
+                st = workflow.getInfoFor(a, 'review_state')
+                if st in omit:
+                    continue
+                # Can the analysis be verified?
+                if not a.isVerifiable(self):
+                    canbeverified = False
+                    break
+            return canbeverified
+
+    def isUserAllowedToVerify(self, member):
+        """
+        Checks if the specified user has enough privileges to verify the
+        current WS. Apart from the roles, this function also checks if the
+        current user has enough privileges to verify all the analyses contained
+        in this Worksheet. Note that this function only returns if the
+        user can verify the worksheet according to his/her privileges
+        and the analyses contained (see isVerifiable function)
+        :member: user to be tested
+        :return: true or false
+        """
+        # Check if the user has "Bika: Verify" privileges
+        username = member.getUserName()
+        allowed = api.user.has_permission(VerifyPermission, username=username)
+        if not allowed:
+            return False
+        # Check if the user is allowed to verify all the contained analyses
+        notallowed = [a for a in self.getAnalyses()
+                      if not a.isUserAllowedToVerify(member)]
+        return not notallowed
+
+    def guard_verify_transition(self):
+        """
+        Checks if the verify transition can be performed to the current
+        Worksheet by the current user depending on the user roles, as
+        well as the statuses of the analyses assigned to this Worksheet
+        :return: true or false
+        """
+        mtool = getToolByName(self, "portal_membership")
+        checkPermission = mtool.checkPermission
+        # Check if the Analysis Request is in a "verifiable" state
+        if self.isVerifiable():
+            # Check if the user can verify the Analysis Request
+            member = mtool.getAuthenticatedMember()
+            return self.isUserAllowedToVerify(member)
+        return False
 
     def workflow_script_submit(self):
         # Don't cascade. Shouldn't be submitting WSs directly for now,

--- a/bika/lims/permissions.py
+++ b/bika/lims/permissions.py
@@ -99,7 +99,6 @@ DisposeSample = 'BIKA: Dispose Sample'
 ImportAnalysis = 'BIKA: Import Analysis'
 Retract = "BIKA: Retract"
 Verify = 'BIKA: Verify'
-VerifyOwnResults = 'BIKA: Verify own results'
 Publish = 'BIKA: Publish'
 EditSample = 'BIKA: Edit Sample'
 EditAR = 'BIKA: Edit AR'

--- a/bika/lims/permissions.zcml
+++ b/bika/lims/permissions.zcml
@@ -69,7 +69,6 @@
 
 <permission id="bika.lims.Retract" title="BIKA: Retract"/>
 <permission id="bika.lims.Verify" title="BIKA: Verify"/>
-<permission id="bika.lims.VerifyOwnResults" title="BIKA: Verify own results"/>
 <permission id="bika.lims.Publish" title="BIKA: Publish"/>
 <permission id="bika.lims.CancelAndReinstate" title="BIKA: Cancel and reinstate"/>
 

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -244,8 +244,6 @@ class BikaGenerator:
         mp(PostInvoiceBatch, ['Manager', 'LabManager', 'Owner'], 1)
 
         mp(CancelAndReinstate, ['Manager', 'LabManager'], 0)
-
-        mp(VerifyOwnResults, ['Manager', ], 1)
         mp(ViewRetractedAnalyses, ['Manager', 'LabManager', 'LabClerk', 'Analyst', ], 0)
 
         mp(ScheduleSampling, ['Manager', 'SamplingCoordinator'], 0)

--- a/bika/lims/skins/bika/guard_verify_transition.py
+++ b/bika/lims/skins/bika/guard_verify_transition.py
@@ -13,106 +13,14 @@
 ##title=
 ##
 
-from AccessControl import getSecurityManager
-from bika.lims.permissions import Verify, VerifyOwnResults
-
-workflow = context.portal_workflow
 checkPermission = context.portal_membership.checkPermission
 
+if hasattr(context, 'guard_verify_transition'):
+    return context.guard_verify_transition()
+
 # Can't do anything to the object if it's cancelled
-# reference and duplicate analyses don't have cancellation_state
-#if context.portal_type == "Analysis":
+workflow = context.portal_workflow
 if workflow.getInfoFor(context, 'cancellation_state', 'active') == "cancelled":
     return False
 
-# All kinds of analyses get their submitter and verifier compared
-if context.portal_type in ("ReferenceAnalysis",
-                           "DuplicateAnalysis"):
-
-    # May we verify results that we ourself submitted?
-    if checkPermission(VerifyOwnResults, context):
-        return True
-
-    # Check for self-submitted Analysis.
-    user_id = getSecurityManager().getUser().getId()
-    self_submitted = False
-    review_history = workflow.getInfoFor(context, 'review_history')
-    review_history = context.reverseList(review_history)
-    for event in review_history:
-        if event.get('action') == 'submit':
-            if event.get('actor') == user_id:
-                self_submitted = True
-            break
-    if self_submitted:
-        return False
-
-if context.portal_type == "AnalysisRequest":
-
-    if not checkPermission(Verify, context):
-        # Allow automatic verify (Disregard permission)
-        # if all analyses are already verified.
-        for analysis in context.getAnalyses(full_objects = True):
-            review_state = workflow.getInfoFor(analysis, 'review_state')
-            if review_state in ('to_be_sampled', 'to_be_preserved',
-                                'sample_due', 'sample_received',
-                                'attachment_due', 'to_be_verified'):
-                return False
-        return True
-
-    # May we verify results that we ourself submitted?
-    if checkPermission(VerifyOwnResults, context):
-        return True
-
-    # Check for self-submitted Analysis.
-    user_id = getSecurityManager().getUser().getId()
-    self_submitted = False
-    for analysis in context.getAnalyses(full_objects = True):
-        review_state = workflow.getInfoFor(analysis, 'review_state')
-        if review_state == 'to_be_verified':
-            review_history = workflow.getInfoFor(analysis, 'review_history')
-            review_history = context.reverseList(review_history)
-            for event in review_history:
-                if event.get('action') == 'submit':
-                    if event.get('actor') == user_id:
-                        self_submitted = True
-                    break
-            if self_submitted:
-                break
-    if self_submitted:
-        return False
-
-if context.portal_type == "Worksheet":
-
-    if not checkPermission(Verify, context):
-        # Allow automatic verify (Disregard permission)
-        # if all analyses are already verified.
-        for analysis in context.getAnalyses(full_objects = True):
-            review_state = workflow.getInfoFor(analysis, 'review_state')
-            if review_state in ('sample_received', 'attachment_due', 'to_be_verified'):
-                return False
-        return True
-
-    # May we verify results that we ourself submitted?
-    if checkPermission(VerifyOwnResults, context):
-        return True
-
-    # Check for self-submitted analyses.
-    user_id = getSecurityManager().getUser().getId()
-    self_submitted = False
-    for analysis in context.getAnalyses():
-        review_state = workflow.getInfoFor(analysis, 'review_state')
-        if review_state == 'to_be_verified':
-            review_history = workflow.getInfoFor(analysis, 'review_history')
-            review_history = context.reverseList(review_history)
-            for event in review_history:
-                if event.get('action') == 'submit':
-                    if event.get('actor') == user_id:
-                        self_submitted = True
-                    break
-            if self_submitted:
-                break
-    if self_submitted:
-        return False
-
 return True
-

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -33,6 +33,7 @@ LIMS-2148: Unable to sort Bika Listing tables
 LIMS-1774: Shiny graphs for result ranges
 LIMS-2257: Scheduled sampling
 LIMS-2255: Switch to Chameleon (five.pt) for rendering TAL templates
+- Add option to allow labman to self-verify analysis results
 - Replacement of pagination by 'Show more' in tables makes the app faster
 - Add Bika LIMS TAL report reference in reports preview
 - Simplify instrument interface creation for basic CSV files


### PR DESCRIPTION
Add an option inside Analysis Service's Edit view to allow the lab manager to disable/enable "self-approval" of results for this Analysis Service. Also, add the same option in Bika Setup, that will act as the default value for all Analysis Services: the option set at Analysis Service level will have priority over the option set in Bika Setup.

When this option is set to enabled, the user will be able to verify those analyses for which he/she has submitted result. For informative purposes, display an icon stating this violation (same user that submit the results, verifies them).

**Self-verify option in Bika Setup**
![allow_verify_bikasetup](https://cloud.githubusercontent.com/assets/832627/20466631/eb2ea186-af76-11e6-9d40-f6dadd169964.png)

**Self-verify option in Analysis Service edit view**
![allow_verify_analysis](https://cloud.githubusercontent.com/assets/832627/20466639/fef41322-af76-11e6-8622-572830334b0b.png)

**Self-verify option disabled (worksheet manage results)**
![allow_verify_ws_disallow](https://cloud.githubusercontent.com/assets/832627/20466643/143289ee-af77-11e6-94f5-e4a1f4b97ee6.png)

**Self-verify option enabled (worksheet manage results)**
![allow_verify_ws_allow](https://cloud.githubusercontent.com/assets/832627/20466647/1e85bf06-af77-11e6-8948-582b710fdcef.png)

