### PR TITLE
Allow multi-approval/multi-verification of results

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -732,9 +732,8 @@ class AnalysesView(BikaListingView):
                 numverifications = service.getNumberOfRequiredVerifications()
                 if numverifications > 1:
                     # More than one verification required, place an icon
-                    # TODO Get the number of verifications already done:
-                    import random
-                    done = random.randint(1, 3)
+                    # Get the number of verifications already done:
+                    done = obj.getNumberOfVerifications()
                     pending = numverifications - done
                     ratio = float(done)/float(numverifications) \
                         if done > 0 else 0

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -741,9 +741,9 @@ class AnalysesView(BikaListingView):
                     scale = '' if ratio < 0.25 else '25' \
                             if ratio < 0.50 else '50' \
                             if ratio < 0.75 else '75'
-                    anchor = "<a href='#' title='%s: %s %s' " \
+                    anchor = "<a href='#' title='%s &#13;%s %s' " \
                              "class='multi-verification scale-%s'>%s/%s</a>"
-                    anchor = anchor % (t(_("Multi verification required")),
+                    anchor = anchor % (t(_("Multi-verification required")),
                                        str(pending),
                                        t(_("verification(s) pending")),
                                        scale, str(done), str(numverifications))
@@ -755,13 +755,13 @@ class AnalysesView(BikaListingView):
                 if allowed and not obj.isUserAllowedToVerify(member):
                     after_icons.append(
                         "<img src='++resource++bika.lims.images/submitted-by-current-user.png' title='%s'/>" %
-                        (t(_("Cannot verify: Submitted by current user")))
+                        (t(_("Cannot verify, submitted by current user")))
                         )
                 elif allowed:
                     if obj.getSubmittedBy() == member.getUser().getId():
                         after_icons.append(
                         "<img src='++resource++bika.lims.images/warning.png' title='%s'/>" %
-                        (t(_("Can be verified, but submitted by current user")))
+                        (t(_("Can verify, but submitted by current user")))
                         )
 
             # add icon for assigned analyses in AR views

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -728,6 +728,27 @@ class AnalysesView(BikaListingView):
             # Submitting user may not verify results unless the user is labman
             # or manager and the AS has isSelfVerificationEnabled set to True
             if items[i]['review_state'] == 'to_be_verified':
+                # If multi-verification required, place an informative icon
+                numverifications = service.getNumberOfRequiredVerifications()
+                if numverifications > 1:
+                    # More than one verification required, place an icon
+                    # TODO Get the number of verifications already done:
+                    import random
+                    done = random.randint(1, 3)
+                    pending = numverifications - done
+                    ratio = float(done)/float(numverifications) \
+                        if done > 0 else 0
+                    scale = '' if ratio < 0.25 else '25' \
+                            if ratio < 0.50 else '50' \
+                            if ratio < 0.75 else '75'
+                    anchor = "<a href='#' title='%s: %s %s' " \
+                             "class='multi-verification scale-%s'>%s/%s</a>"
+                    anchor = anchor % (t(_("Multi verification required")),
+                                       str(pending),
+                                       t(_("verification(s) pending")),
+                                       scale, str(done), str(numverifications))
+                    after_icons.append(anchor)
+
                 username = member.getUserName()
                 allowed = api.user.has_permission(VerifyPermission,
                                                   username=username)

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -206,7 +206,25 @@ class WorkflowAction:
                 allowed_transitions = [it['id'] for it in \
                                        workflow.getTransitionsFor(item)]
                 if action in allowed_transitions:
-                    success, message = doActionFor(item, action)
+                    success = False
+                    # if action is "verify" and the item is an analysis or
+                    # reference analysis, check if the if the required number
+                    # of verifications done for the analysis is, at least,
+                    # the number of verifications performed previously+1
+                    if (action == 'verify' and
+                        hasattr(item, 'getNumberOfVerifications') and
+                        hasattr(item, 'getNumberOfRequiredVerifications')):
+                        success = True
+                        revers = item.getNumberOfRequiredVerifications()
+                        nmvers = item.getNumberOfVerifications()
+                        item.setNumberOfVerifications(nmvers+1)
+                        if revers-nmvers <= 1:
+                            success, message = doActionFor(item, action)
+                            if not success:
+                                # If failed, restore to the previous number
+                                analysis.setNumberOfVerifications(numvers)
+                    else:
+                        success, message = doActionFor(item, action)
                     if success:
                         transitioned.append(item.id)
                     else:

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -208,9 +208,20 @@ schema = BikaSchema.copy() + Schema((
             label = _("Uncertainty"),
         ),
     ),
-    StringField('DetectionLimitOperand',
-    ),
+    StringField('DetectionLimitOperand',),
 
+    # Required number of required verifications before this analysis being
+    # transitioned to a 'verified' state. This value is set automatically
+    # when the analysis is created, based on the value set for the property
+    # NumberOfRequiredVerifications from the Analysis Service
+    IntegerField('NumberOfRequiredVerifications', default=1),
+
+    # Number of verifications done for this analysis. Each time a 'verify'
+    # transition takes place, this value is updated accordingly. The
+    # transition will finally succeed when the NumberOfVerifications matches
+    # with the NumberOfRequiredVerifications. Meanwhile, the state of the
+    # object will remain in 'to_be_verified'
+    IntegerField('NumberOfVerifications', default=0),
 ),
 )
 
@@ -1303,6 +1314,9 @@ class Analysis(BaseContent):
             SamplePartition=self.getSamplePartition())
         analysis.setDetectionLimitOperand(self.getDetectionLimitOperand())
         analysis.setResult(self.getResult())
+        # Required number of verifications
+        reqvers = self.getNumberOfRequiredVerifications()
+        analysis.setNumberOfRequiredVerifications(reqvers)
         analysis.unmarkCreationFlag()
 
         # zope.event.notify(ObjectInitializedEvent(analysis))

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2809,7 +2809,15 @@ class AnalysisRequest(BaseFolder):
             # verify all analyses in this AR.
             analyses = self.getAnalyses(review_state='to_be_verified')
             for analysis in analyses:
-                doActionFor(analysis.getObject(), "verify")
+                # For the 'verify' transition to (effectively) take place,
+                # we need to check if the required number of verifications for
+                # the analysis is, at least, the number of verifications
+                # performed previously +1
+                revers = analysis.getNumberOfRequiredVerifications()
+                nmvers = analysis.getNumberOfVerifications()
+                analysis.setNumberOfVerifications(nmvers+1)
+                if revers-nmvers <= 1:
+                    doActionFor(analysis.getObject(), "verify")
 
     def workflow_script_publish(self):
         if skip(self, "publish"):

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -974,7 +974,7 @@ schema = BikaSchema.copy() + Schema((
          ),
     ),
     IntegerField(
-        'NumberOfRequiredVerifications',
+        '_NumberOfRequiredVerifications',
         schemata="Analysis",
         default=-1,
         vocabulary="_getNumberOfRequiredVerificationsVocabulary",
@@ -1433,6 +1433,17 @@ class AnalysisService(BaseContent, HistoryAwareMixin):
         bsval = "%s (%s)" % (_("System default"), bsve)
         items = [(-1, bsval), (0, _('No')), (1, _('Yes'))]
         return IntDisplayList(list(items))
+
+    def getNumberOfRequiredVerifications(self):
+        """
+        Returns the number of required verifications a test for this analysis
+        requires before being transitioned to 'verified' state
+        :return: number of required verifications
+        """
+        num = self.get_NumberOfRequiredVerifications()
+        if num < 1:
+            return self.bika_setup.getNumberOfRequiredVerifications()
+        return num
 
     def _getNumberOfRequiredVerificationsVocabulary(self):
         """

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -22,6 +22,7 @@ from Products.Archetypes.public import DisplayList, ReferenceField, \
     IntegerWidget, StringWidget, BaseContent, \
     Schema, registerType, MultiSelectionWidget, \
     FloatField, DecimalWidget
+from Products.Archetypes.utils import IntDisplayList
 from Products.Archetypes.references import HoldingReference
 from Products.CMFCore.permissions import View, ModifyPortalContent
 from Products.CMFCore.utils import getToolByName
@@ -963,10 +964,27 @@ schema = BikaSchema.copy() + Schema((
         widget=SelectionWidget(
             label=_("Self-verification of results"),
             description=_(
-                "If enabled, the same user who submitted a result for this "
-                "analysis will be able to verify it. Note only Lab Managers "
-                "can verify results. The option set here has priority over "
-                "the option set in Bika Setup"),
+                "If enabled, a user who submitted a result for this analysis "
+                "will also be able to verify it. This setting take effect for "
+                "those users with a role assigned that allows them to verify "
+                "results (by default, managers, labmanagers and verifiers). "
+                "The option set here has priority over the option set in Bika "
+                "Setup"),
+            format="select",
+         ),
+    ),
+    IntegerField(
+        'NumberOfRequiredVerifications',
+        schemata="Analysis",
+        default=-1,
+        vocabulary="_getNumberOfRequiredVerificationsVocabulary",
+        widget=SelectionWidget(
+            label=_("Number of required verifications"),
+            description=_(
+                "Number of required verifications from different users with "
+                "enough privileges before a given result for this analysis "
+                "being considered as 'verified'. The option set here has "
+                "priority over the option set in Bika Setup"),
             format="select",
          ),
     ),
@@ -1413,8 +1431,20 @@ class AnalysisService(BaseContent, HistoryAwareMixin):
         bsve = self.bika_setup.getSelfVerificationEnabled()
         bsve = _('Yes') if bsve else _('No')
         bsval = "%s (%s)" % (_("System default"), bsve)
-        items = [('-1', bsval), ('0', _('No')), ('1', _('Yes'))]
-        return DisplayList(list(items))
+        items = [(-1, bsval), (0, _('No')), (1, _('Yes'))]
+        return IntDisplayList(list(items))
+
+    def _getNumberOfRequiredVerificationsVocabulary(self):
+        """
+        Returns a DisplayList with the available options for the
+        multi-verification list: 'system default', '1', '2', '3', '4'
+        :return: DisplayList with the available options for the
+            multi-verification list
+        """
+        bsve = self.bika_setup.getNumberOfRequiredVerifications()
+        bsval = "%s (%s)" % (_("System default"), str(bsve))
+        items = [(-1, bsval), (1, '1'), (2, '2'), (3, '3'), (4, '4')]
+        return IntDisplayList(list(items))
 
     def workflow_script_activate(self):
         workflow = getToolByName(self, 'portal_workflow')

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -363,10 +363,9 @@ schema = BikaFolderSchema.copy() + Schema((
         widget=SelectionWidget(
             label=_("Number of required verifications"),
             description=_(
-                "Number of required verifications from different users with "
-                "enough privileges before a given result for being considered "
-                "as 'verified'. This setting can be overrided for a given "
-                "Analysis in Analysis Service edit view. By default, 1"),
+                "Number of required verifications before a given result being "
+                "considered as 'verified'. This setting can be overrided for "
+                "any Analysis in Analysis Service edit view. By default, 1"),
             format="select",
          ),
     ),

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -347,10 +347,27 @@ schema = BikaFolderSchema.copy() + Schema((
         widget=BooleanWidget(
             label=_("Allow self-verification of results"),
             description=_(
-                "If enabled, the same user who submitted a result "
-                "for this analysis will be able to verify it. Note "
-                "only Lab Managers can verify results. Disabled by "
-                "default"),
+                "If enabled, a user who submitted a result will also be able "
+                "to verify it. This setting only take effect for those users "
+                "with a role assigned that allows them to verify results "
+                "(by default, managers, labmanagers and verifiers)."
+                "This setting can be overrided for a given Analysis in "
+                "Analysis Service edit view. By default, disabled."),
+         ),
+    ),
+    IntegerField(
+        'NumberOfRequiredVerifications',
+        schemata="Analyses",
+        default=1,
+        vocabulary="_getNumberOfRequiredVerificationsVocabulary",
+        widget=SelectionWidget(
+            label=_("Number of required verifications"),
+            description=_(
+                "Number of required verifications from different users with "
+                "enough privileges before a given result for being considered "
+                "as 'verified'. This setting can be overrided for a given "
+                "Analysis in Analysis Service edit view. By default, 1"),
+            format="select",
          ),
     ),
     ReferenceField('DryMatterService',
@@ -682,6 +699,16 @@ class BikaSetup(folder.ATFolder):
             return True if checkbox == 'on' and len(widget[0]) > 1 else False
         else:
             return False
+
+    def _getNumberOfRequiredVerificationsVocabulary(self):
+        """
+        Returns a DisplayList with the available options for the
+        multi-verification list: '1', '2', '3', '4'
+        :return: DisplayList with the available options for the
+            multi-verification list
+        """
+        items = [(1, '1'), (2, '2'), (3, '3'), (4, '4')]
+        return IntDisplayList(list(items))
 
 
 registerType(BikaSetup, PROJECTNAME)

--- a/bika/lims/content/duplicateanalysis.py
+++ b/bika/lims/content/duplicateanalysis.py
@@ -130,6 +130,10 @@ schema = schema.copy() + Schema((
         'Keyword',
         expression="context.getAnalysis().getKeyword()",
     ),
+    ComputedField(
+        'NumberOfRequiredVerifications',
+        expression='context.getAnalysis().getNumberOfRequiredVerifications()',
+    )
 ),
 )
 

--- a/bika/lims/content/referenceanalysis.py
+++ b/bika/lims/content/referenceanalysis.py
@@ -130,6 +130,19 @@ schema = BikaSchema.copy() + Schema((
             label = _("Uncertainty"),
         ),
     ),
+
+    # Required number of required verifications before this analysis being
+    # transitioned to a 'verified' state. This value is set automatically
+    # when the analysis is created, based on the value set for the property
+    # NumberOfRequiredVerifications from the Analysis Service
+    IntegerField('NumberOfRequiredVerifications', default=1),
+
+    # Number of verifications done for this analysis. Each time a 'verify'
+    # transition takes place, this value is updated accordingly. The
+    # transition will finally succeed when the NumberOfVerifications matches
+    # with the NumberOfRequiredVerifications. Meanwhile, the state of the
+    # object will remain in 'to_be_verified'
+    IntegerField('NumberOfVerifications', default=0),
 ),
 )
 

--- a/bika/lims/skins/bika/bika_listing.css.dtml
+++ b/bika/lims/skins/bika/bika_listing.css.dtml
@@ -551,4 +551,20 @@ table.bika-listing-table-transposed table.worksheet-position tbody tr {
     color: #205c90 !important;
     padding: 4px 10px;
 }
+#content .bika-listing-table a.multi-verification {
+    background-color: #b42e29;
+    border-radius: 5px;
+    color: #fff !important;
+    margin: 0 4px;
+    padding: 1px 4px;
+}
+#content .bika-listing-table a.multi-verification.scale-25 {
+    background-color:#c36349;
+}
+#content .bika-listing-table a.multi-verification.scale-50 {
+    background-color:#c89e55;
+}
+#content .bika-listing-table a.multi-verification.scale-75 {
+    background-color:#afb064;
+}
 /* </dtml-with> */

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -117,6 +117,8 @@ def create_analysisrequest(context, request, values, analyses=None,
 
     # Set the state of analyses we created.
     for analysis in analyses:
+        revers = analysis.getService().getNumberOfRequiredVerifications()
+        analysis.setNumberOfRequiredVerifications(revers)
         doActionFor(analysis, 'sample_due')
         analysis_state = workflow.getInfoFor(analysis, 'review_state')
         if analysis_state not in skip_receive:

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -34,6 +34,7 @@ LIMS-2148: Unable to sort Bika Listing tables
 LIMS-1774: Shiny graphs for result ranges
 LIMS-2257: Scheduled sampling
 LIMS-2255: Switch to Chameleon (five.pt) for rendering TAL templates
+- Add option to allow multi-approval (multi-verification) of results
 - Added Analyses section in the Dashboard
 - Add option to allow labman to self-verify analysis results
 - Replacement of pagination by 'Show more' in tables makes the app faster


### PR DESCRIPTION
In the Analysis Service edit view, a selection list to set the number of verifications required will be displayed (by default, 'system default'). Add the same configuration parameter in Bika Setup. The option set in Analysis Services will have priority over the option set at Bika Setup.

When enabled (>1 verifications), the analysis will require the verification from at least two different labmanagers. For informative purposes, display an icon stating this “multi-verification” next to the result.

This functionality doesn't override #1864 , so both features could coexist at the same time for the same analysis, so the same user that entered the result will be able to do the double verification if both options are enabled for a given analysis.

**Option for multi-approval in Bika Setup**
![multi-bikasetup](https://cloud.githubusercontent.com/assets/832627/20505615/882a5caa-b04e-11e6-9721-316b1ab8e83d.png)

**Option for multi-approval in Analysis Service Edit view**
![multi-as](https://cloud.githubusercontent.com/assets/832627/20505618/8c5fde9e-b04e-11e6-878c-da0a053b2cf8.png)

**Worksheet's results entry with analyses in different statuses of verification (including a duplicate)**
![multi-verify](https://cloud.githubusercontent.com/assets/832627/20505629/9b7ffec2-b04e-11e6-90c9-932d098e33c0.png)
