### PR TITLE
Use the analysis' numberofrequiredverifications instead of service's

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -729,7 +729,7 @@ class AnalysesView(BikaListingView):
             # or manager and the AS has isSelfVerificationEnabled set to True
             if items[i]['review_state'] == 'to_be_verified':
                 # If multi-verification required, place an informative icon
-                numverifications = service.getNumberOfRequiredVerifications()
+                numverifications = obj.getNumberOfRequiredVerifications()
                 if numverifications > 1:
                     # More than one verification required, place an icon
                     # Get the number of verifications already done:


### PR DESCRIPTION
Use the analysis' number of required verifications instead of the service's. Otherwise, and if the service's setting is updated, the analyses list will not display the correct number of verifications pending for a given analysis.