### PR TITLE
LIMS-2455: (Lab)Contact/User Linkage Behavior

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -30,3 +30,4 @@ Jonas Daniel <jonas@ogaard.no>
 Luke Williams <luke@iquidus.co.nz>
 Manav Batra <manavbatra@outlook.com>
 Aman Arora <aman2arora2@gmail.com>
+Ramon Bartl <rb@ridingbytes.com>

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -18,6 +18,7 @@ from bika.lims import PMF
 from bika.lims import logger
 from bika.lims.browser import BrowserView
 from bika.lims.content.contact import Contact
+from bika.lims.content.labcontact import LabContact
 from bika.lims import bikaMessageFactory as _
 
 
@@ -100,7 +101,8 @@ class ContactLoginDetailsView(BrowserView):
 
             # Skip users which are already linked to a Contact
             contact = Contact.getContactByUsername(userid)
-            if contact:
+            labcontact = LabContact.getContactByUsername(userid)
+            if contact or labcontact:
                 continue
 
             userdata = {
@@ -120,6 +122,20 @@ class ContactLoginDetailsView(BrowserView):
 
         out.sort(lambda x, y: cmp(x["fullname"], y["fullname"]))
         return out
+
+    def is_contact(self):
+        """Check if the current context is a Contact
+        """
+        if self.context.portal_type == "Contact":
+            return True
+        return False
+
+    def is_labcontact(self):
+        """Check if the current context is a LabContact
+        """
+        if self.context.portal_type == "LabContact":
+            return True
+        return False
 
     def _link_user(self, userid):
         """Link an existing user to the current Contact

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -6,6 +6,7 @@
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 import re
+
 from Acquisition import aq_base
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -24,12 +25,14 @@ class ContactLoginDetailsView(BrowserView):
     """Contact Login View
     """
     template = ViewPageTemplateFile("templates/login_details.pt")
-    searchstring = ""
 
     def __call__(self):
         request = self.request
         form = request.form
         CheckAuthenticator(form)
+
+        self.newSearch = False
+        self.searchstring = form.get("searchstring", "")
 
         if form.get("submitted"):
             logger.debug("Form Submitted: {}".format(form))
@@ -39,6 +42,7 @@ class ContactLoginDetailsView(BrowserView):
                 self._unlink_user(delete=True)
             elif form.get("search_button", False):
                 logger.debug("Search User")
+                self.newSearch = True
             elif form.get("link_button", False):
                 logger.debug("Link User")
                 self._link_user(form.get("userid"))
@@ -89,7 +93,6 @@ class ContactLoginDetailsView(BrowserView):
         """Search Plone users which are not linked to a contact
         """
         users = api.user.get_users()
-        self.searchstring = self.request.form.get("searchstring")
 
         out = []
         for user in users:
@@ -115,7 +118,7 @@ class ContactLoginDetailsView(BrowserView):
             # Append the userdata for the results
             out.append(userdata)
 
-        out.sort(lambda x, y: cmp(x["userid"], y["userid"]))
+        out.sort(lambda x, y: cmp(x["fullname"], y["fullname"]))
         return out
 
     def _link_user(self, userid):

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -68,10 +68,15 @@
                                 <span i18n:translate="">User Name</span>
                             </td>
                             <td>
+                                <tal:labcontact condition="view/is_labcontact">
                                 <a href="#"
                                    tal:attributes="href userprops/edit_url">
-                                    <span tal:replace="userprops/id"></span>
+                                    <span tal:replace="userprops/id">labuser</span>
                                 </a>
+                                </tal:labcontact>
+                                <tal:contact condition="view/is_contact">
+                                    <span tal:replace="userprops/id">customeruser</span>
+                                </tal:contact>
                             </td>
                         </tr>
                         <tr>
@@ -81,7 +86,7 @@
                             <td>
                                 <a href="#"
                                    tal:attributes="href string:mailto:${userprops/email}"
-                                   tal:content="userprops/email"></a>
+                                   tal:content="userprops/email">labcontact@bikalims.com</a>
                             </td>
                         </tr>
                         <tr>
@@ -126,7 +131,7 @@
 
     <!-- Contact has **no** linked User -->
     <tal:withoutuser condition="not:has_user"
-                     define="contactprops view/get_contact_properties">
+                     define="contactprops view/get_contact_properties;">
 
         <p i18n:translate="">
             No user exists for
@@ -177,7 +182,10 @@
                                    tal:attributes="href string:mailto:${user/email}"
                                    tal:content="user/email"></a>
                                 </td>
-                                <td tal:content="user/userid">Username</td>
+                                <td>
+                                    <span tal:replace="user/userid">customeruser</span>
+                                </td>
+
                         </tr>
                     </tbody>
                 </table>
@@ -257,7 +265,7 @@
                     <input type="text" name="email" size="30" tal:attributes="value python: context.getEmailAddress() and context.getEmailAddress() or view.request.get('email', '')"/> </div>
 
                     <div class="field"
-                         tal:condition="python: view.context.portal_type == 'LabContact'">
+                         tal:condition="view/is_labcontact">
                         <label i18n:translate="label_add_to_groups">Add to the following groups:</label>
                         <span class="fieldRequired" i18n:translate="">(Required)</span>
                         <br/>

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -20,7 +20,9 @@
     <!-- Contact has a linked User -->
     <tal:withuser condition="has_user"
                   define="userprops    view/get_user_properties;
-                          contactprops view/get_contact_properties">
+                          contactprops view/get_contact_properties;
+                          active       context/isActive;
+                          inactive     not: active">
 
         <p i18n:translate="">
             <span tal:content="contactprops/fullname"
@@ -38,14 +40,13 @@
 
 
         <fieldset>
-            <legend i18n:translate="">Manage linked System User</legend>
+            <legend i18n:translate="">Manage linked User</legend>
 
             <form id="contact_edit_form"
                   method="post">
 
                 <span tal:replace="structure context/@@authenticator/authenticator"/>
                 <input type="hidden" name="submitted" value="1"/>
-
 
                 <table class="plain">
                     <tbody>
@@ -95,7 +96,15 @@
                 </table>
 
                 <!-- Form Controls -->
-                <div class="formControls">
+                <div class="formControls" tal:condition="active">
+                    <input class="context"
+                           style="color:red;"
+                           type="submit"
+                           tabindex=""
+                           name="delete_button"
+                           value="Unlink and delete User"
+                           i18n:attributes="value"
+                           tal:attributes="tabindex tabindex/next;" />
                     <input class="context"
                            type="submit"
                            tabindex=""
@@ -103,23 +112,13 @@
                            value="Unlink User"
                            i18n:attributes="value"
                            tal:attributes="tabindex tabindex/next;" />
-
-                    <input class="context"
-                           type="submit"
-                           tabindex=""
-                           name="delete_button"
-                           value="Unlink and delete User"
-                           i18n:attributes="value"
-                           tal:attributes="tabindex tabindex/next;" />
-
-                    <!-- <input class="context" -->
-                    <!-- type="submit" -->
-                    <!-- tabindex="" -->
-                    <!-- name="deactivate_button" -->
-                    <!-- value="Deactivate User" -->
-                    <!-- i18n:attributes="value" -->
-                    <!-- tal:attributes="tabindex tabindex/next;" /> -->
                 </div>
+                <p tal:condition="inactive">
+                    <img src="++resource++bika.lims.images/exclamation2.png" title="Disabled Contact">
+                    <span i18n:translate="" class="discreet">
+                        Contact is deactivated. User cannot be unlinked.
+                    </span>
+                </p>
             </form>
         </fieldset>
     </tal:withuser>
@@ -142,7 +141,7 @@
                         batch python:Batch(view.linkable_users(), b_size, int(b_start), orphan=1) or None;
                         batchformkeys python:['searchstring','_authenticator'];">
 
-            <legend i18n:translate="">Link an existing System User</legend>
+            <legend i18n:translate="">Link an existing User</legend>
             <form id="user_search_form"
                   method="post">
 
@@ -201,7 +200,7 @@
         </fieldset>
 
         <fieldset>
-            <legend i18n:translate="">Create a new System User</legend>
+            <legend i18n:translate="">Create a new User</legend>
 
             <form id="contact_edit_form"
                   method="post">

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -1,136 +1,289 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:tal="http://xml.zope.org/namespaces/tal"
-	xmlns:metal="http://xml.zope.org/namespaces/metal"
-	xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-	metal:use-macro="here/main_template/macros/master"
-	i18n:domain="bika">
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="bika">
 
 <body>
 
 <metal:title fill-slot="content-title">
-	<h1 i18n:translate="">Login details</h1>
+    <h1 i18n:translate="">Login details</h1>
 </metal:title>
 
-<metal:description fill-slot="content-description">
-	<p i18n:translate="" tal:condition="context/hasUser">
-		<span tal:content="here/getFullname" i18n:name="contact_fullname">Pete Smith</span>
-		can log into the LIMS by using
-		<strong tal:content="here/getUsername" i18n:name="contact_username">username</strong>
-		as username. Contacts must change their own
-		passwords. If a password is forgotten a contact
-		can request a new password from the login form.
-	</p>
-	<div class="portalMessage" i18n:translate=""
-		tal:condition="not:context/hasUser">
-		No user exists for
-		<span tal:content="here/getFullname" i18n:name="contact_fullname">Pete Smith</span>
-		and he/she will not be able to log in.
-		Fill in the form below to create one for him/her.
-	</div>
-</metal:description>
-
-<metal:content fill-slot="content-core" tal:define="
-	portal context/@@plone_portal_state/portal;
-	tabindex view/tabindex;">
-
-	<form id="contact_edit_form"
-		method="post"
-		tal:condition="not:here/hasUser">
-
-		<span tal:replace="structure context/@@authenticator/authenticator"/>
-		<input type="hidden" name="submitted" value="1"/>
-		<input type="hidden"
-			name="fullname"
-			value="fullname"
-			tal:attributes="value here/getFullname"/>
-
-		<fieldset>
-
-			<div class="field">
-				<label i18n:translate="">User Name</label>
-				<span class="fieldRequired" title="Required"
-					i18n:attributes="title"
-					i18n:translate="">(Required)</span>
-				<div i18n:translate="">
-					Enter a user name, usually something like
-					'jsmith'. No spaces or special characters.
-					Usernames and passwords are case sensitive,
-					make sure the caps lock key is not enabled.
-					This is the name used to log in.
-				</div>
-				<input type="text" name="username" size="30"
-					tal:attributes="value python:view.request.get('username', '')"/>
-			</div>
+<metal:content fill-slot="content-core"
+               tal:define="portal context/@@plone_portal_state/portal;
+                           has_user context/hasUser;
+                           tabindex view/tabindex;">
 
 
-<!--			<tal:password condition="not:context/portal_properties/site_properties/validate_email|nothing">-->
-			<div class="field"
-				tal:condition="python:context.portal_membership.checkPermission('Add portal member', context)">
-					<label i18n:translate="">Password</label>
-					<span class="fieldRequired" title="Required"
-						i18n:attributes="title"
-						i18n:translate="">(Required)</span>
-					<div class="formHelp" i18n:translate="">
-						Minimum 5 characters.
-					</div>
-					<input type="password" name="password" size="10"/>
-				</div>
+    <!-- Contact has a linked User -->
+    <tal:withuser condition="has_user"
+                  define="userprops    view/get_user_properties;
+                          contactprops view/get_contact_properties">
 
-			<div class="field"
-				tal:condition="python:context.portal_membership.checkPermission('Add portal member', context)">
-					<label i18n:translate="">Confirm password</label>
-					<span class="fieldRequired" title="Required"
-						i18n:attributes="title"
-						i18n:translate="">(Required)</span>
-					<div class="formHelp" i18n:translate="">
-						Re-enter the password. Make sure the passwords are identical.
-					</div>
-					<input type="password" name="confirm" size="10"/>
-			</div>
-<!--			</tal:password>-->
+        <p i18n:translate="">
+            <span tal:content="contactprops/fullname"
+                    i18n:name="contact_fullname">
+                Pete Smith
+            </span>
+            can log into the LIMS by using
+            <strong tal:content="contactprops/username"
+                    i18n:name="contact_username">
+                username
+            </strong>
+            as username. Contacts must change their own passwords.
+            If a password is forgotten a contact can request a new password from the login form.
+        </p>
 
-			<div class="field">
-                <label i18n:translate="">Email</label>
-				<span class="fieldRequired" title="Required"
-					i18n:attributes="title"
-					i18n:translate="">(Required)</span>
-				<div class="formHelp" i18n:translate="">
-					Enter an email address. This is necessary in case the password
-					is lost. We respect your privacy, and will not give the address
-					away to any third parties or expose it anywhere.
-				</div>
-				<input type="text" name="email" size="30"
-					tal:attributes="value python: context.getEmailAddress() and context.getEmailAddress() or view.request.get('email', '')"/>
-			</div>
 
-            <div class="field"
-                 tal:condition="python: view.context.portal_type == 'LabContact'">
-                <label i18n:translate="label_add_to_groups">Add to the following groups:</label>
-                <span class="fieldRequired" i18n:translate="">(Required)</span>
-                <br/>
-                <select name="groups" size="10" multiple="1">
-                    <option value='LabManagers'>LabManagers</option>
-                    <option value='LabClerks'>LabClerks</option>
-                    <option value='Analysts'>Analysts</option>
-                    <option value='Verifiers'>Verifiers</option>
-                    <option value='Samplers'>Samplers</option>
-                    <option value='Preservers'>Preservers</option>
-                    <option value='Publishers'>Publishers</option>
-                    <option value='Reviewers'>Reviewers</option>
-                </select>
-            </div>
+        <fieldset>
+            <legend i18n:translate="">Manage linked System User</legend>
 
-			<input class="context allowMultiSubmit"
-				type="submit"
-				tabindex=""
-				name="save_button"
-				value="Save"
-				i18n:attributes="value"
-				tal:attributes="tabindex tabindex/next;" />
+            <form id="contact_edit_form"
+                  method="post">
 
-		</fieldset>
+                <span tal:replace="structure context/@@authenticator/authenticator"/>
+                <input type="hidden" name="submitted" value="1"/>
 
-	</form>
+
+                <table class="plain">
+                    <tbody>
+                        <tr>
+                            <td rowspan="5">
+                                <img tal:replace="structure userprops/portrait"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span i18n:translate="">Full Name</span>
+                            </td>
+                            <td>
+                                <span tal:replace="userprops/fullname"></span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span i18n:translate="">User Name</span>
+                            </td>
+                            <td>
+                                <a href="#"
+                                   tal:attributes="href userprops/edit_url">
+                                    <span tal:replace="userprops/id"></span>
+                                </a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span i18n:translate="">Email</span>
+                            </td>
+                            <td>
+                                <a href="#"
+                                   tal:attributes="href string:mailto:${userprops/email}"
+                                   tal:content="userprops/email"></a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span i18n:translate="">Last Login Time</span>
+                            </td>
+                            <td>
+                                <span tal:replace="python:context.toLocalizedTime(userprops['last_login_time'], long_format=1)"></span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <!-- Form Controls -->
+                <div class="formControls">
+                    <input class="context"
+                           type="submit"
+                           tabindex=""
+                           name="unlink_button"
+                           value="Unlink User"
+                           i18n:attributes="value"
+                           tal:attributes="tabindex tabindex/next;" />
+
+                    <input class="context"
+                           type="submit"
+                           tabindex=""
+                           name="delete_button"
+                           value="Unlink and delete User"
+                           i18n:attributes="value"
+                           tal:attributes="tabindex tabindex/next;" />
+
+                    <!-- <input class="context" -->
+                    <!-- type="submit" -->
+                    <!-- tabindex="" -->
+                    <!-- name="deactivate_button" -->
+                    <!-- value="Deactivate User" -->
+                    <!-- i18n:attributes="value" -->
+                    <!-- tal:attributes="tabindex tabindex/next;" /> -->
+                </div>
+            </form>
+        </fieldset>
+    </tal:withuser>
+    <!-- /Contact has a linked User -->
+
+    <!-- Contact has **no** linked User -->
+    <tal:withoutuser condition="not:has_user"
+                     define="contactprops view/get_contact_properties">
+
+        <p i18n:translate="">
+            No user exists for
+            <span tal:content="here/getFullname" i18n:name="contact_fullname">Pete Smith</span>
+            and he/she will not be able to log in. Fill in the form below to create one for him/her.
+        </p>
+
+        <fieldset
+            tal:define="Batch python:modules['Products.CMFPlone'].Batch;
+                        b_size python:5;
+                        b_start python:request.get('b_start', 0);
+                        batch python:Batch(view.linkable_users(), b_size, int(b_start), orphan=1) or None;
+                        batchformkeys python:['searchstring','_authenticator'];">
+
+            <legend i18n:translate="">Link an existing System User</legend>
+            <form id="user_search_form"
+                  method="post">
+
+                <span tal:replace="structure context/@@authenticator/authenticator"/>
+                <input type="hidden" name="submitted" value="1"/>
+
+                <table class="listing">
+                    <thead>
+                        <tr>
+                            <th colspan="4" class="nosort">
+                                <input class="quickSearch" type="text" name="searchstring" value="" tal:attributes="value view/searchstring">
+                                <input type="submit" class="searchButton" name="search_button" value="Suche">
+                            </th>
+                        </tr>
+                        <tr>
+                            <th class="nosort"></th>
+                            <th i18n:translate="">Full Name</th>
+                            <th i18n:translate="">Email</th>
+                            <th i18n:translate="">User Name</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr tal:repeat="user batch">
+                            <td>
+                                <input type="radio"
+                                       name="userid"
+                                       value=""
+                                       tal:attributes="value user/userid">
+                            </td>
+                            <td tal:content="user/fullname">Fullname</td>
+                            <td>
+                                <a href="#"
+                                   tal:attributes="href string:mailto:${user/email}"
+                                   tal:content="user/email"></a>
+                                </td>
+                                <td tal:content="user/userid">Username</td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <div class="discreet">
+                    <div metal:use-macro="context/batch_macros/macros/navigation" />
+                </div>
+
+                <!-- Form Controls -->
+                <div class="formControls">
+                    <input class="context allowMultiSubmit"
+                           type="submit"
+                           tabindex=""
+                           name="link_button"
+                           value="Link User"
+                           i18n:attributes="value"
+                           tal:attributes="tabindex tabindex/next;" />
+                </div>
+            </form>
+        </fieldset>
+
+        <fieldset>
+            <legend i18n:translate="">Create a new System User</legend>
+
+            <form id="contact_edit_form"
+                  method="post">
+
+                <span tal:replace="structure context/@@authenticator/authenticator"/>
+                <input type="hidden" name="submitted" value="1"/>
+                <input type="hidden" name="fullname" value="fullname" tal:attributes="value here/getFullname"/>
+
+
+                <div class="field">
+                    <label i18n:translate="">User Name</label>
+                    <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
+                    <div i18n:translate="">
+                        Enter a user name, usually something like
+                        'jsmith'. No spaces or special characters.
+                        Usernames and passwords are case sensitive,
+                        make sure the caps lock key is not enabled.
+                        This is the name used to log in.
+                    </div>
+                    <input type="text" name="username" size="30" tal:attributes="value python:view.request.get('username', '')"/>
+                </div>
+
+
+                <!--<tal:password condition="not:context/portal_properties/site_properties/validate_email|nothing">-->
+                <div class="field" tal:condition="python:context.portal_membership.checkPermission('Add portal member', context)">
+                    <label i18n:translate="">Password</label>
+                    <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
+                    <div class="formHelp" i18n:translate="">
+                        Minimum 5 characters.
+                    </div>
+                    <input type="password" name="password" size="10"/>
+                </div>
+
+                <div class="field" tal:condition="python:context.portal_membership.checkPermission('Add portal member', context)">
+                    <label i18n:translate="">Confirm password</label>
+                    <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
+                    <div class="formHelp" i18n:translate="">
+                        Re-enter the password. Make sure the passwords are identical.
+                    </div>
+                    <input type="password" name="confirm" size="10"/>
+                </div>
+                <!--			</tal:password>-->
+
+                <div class="field">
+                    <label i18n:translate="">Email</label>
+                    <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
+                    <div class="formHelp" i18n:translate="">
+                        Enter an email address. This is necessary in case the password
+                        is lost. We respect your privacy, and will not give the address
+                        away to any third parties or expose it anywhere.
+                    </div>
+                    <input type="text" name="email" size="30" tal:attributes="value python: context.getEmailAddress() and context.getEmailAddress() or view.request.get('email', '')"/> </div>
+
+                    <div class="field"
+                         tal:condition="python: view.context.portal_type == 'LabContact'">
+                        <label i18n:translate="label_add_to_groups">Add to the following groups:</label>
+                        <span class="fieldRequired" i18n:translate="">(Required)</span>
+                        <br/>
+                        <select name="groups" size="10" multiple="1">
+                            <option value='LabManagers'>LabManagers</option>
+                            <option value='LabClerks'>LabClerks</option>
+                            <option value='Analysts'>Analysts</option>
+                            <option value='Verifiers'>Verifiers</option>
+                            <option value='Samplers'>Samplers</option>
+                            <option value='Preservers'>Preservers</option>
+                            <option value='Publishers'>Publishers</option>
+                            <option value='Reviewers'>Reviewers</option>
+                        </select>
+                    </div>
+
+                    <input class="context allowMultiSubmit"
+                           type="submit"
+                           tabindex=""
+                           name="save_button"
+                           value="Save"
+                           i18n:attributes="value"
+                           tal:attributes="tabindex tabindex/next;" />
+
+            </form>
+        </fieldset>
+    </tal:withoutuser>
+    <!-- /Contact has **no** linked User -->
 
 </metal:content>
 

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -135,17 +135,17 @@
         </p>
 
         <fieldset
-            tal:define="Batch python:modules['Products.CMFPlone'].Batch;
+            tal:define="Batch python:modules['plone.batching'].Batch;
                         b_size python:5;
-                        b_start python:request.get('b_start', 0);
+                        b_start python:0 if view.newSearch else request.get('b_start', 0);
                         batch python:Batch(view.linkable_users(), b_size, int(b_start), orphan=1) or None;
-                        batchformkeys python:['searchstring','_authenticator'];">
+                        batchformkeys python:['_authenticator'];">
 
             <legend i18n:translate="">Link an existing User</legend>
             <form id="user_search_form"
                   method="post">
 
-                <span tal:replace="structure context/@@authenticator/authenticator"/>
+                <input tal:replace="structure context/@@authenticator/authenticator"/>
                 <input type="hidden" name="submitted" value="1"/>
 
                 <table class="listing">
@@ -183,7 +183,9 @@
                 </table>
 
                 <div class="discreet">
-                    <div metal:use-macro="context/batch_macros/macros/navigation" />
+                    <tal:batchnavigation
+                        define="batchnavigation nocall:context/@@batchnavigation"
+                        replace="structure python:batchnavigation(batch, batchformkeys)" />
                 </div>
 
                 <!-- Form Controls -->

--- a/bika/lims/content/contact.py
+++ b/bika/lims/content/contact.py
@@ -203,7 +203,7 @@ class Contact(Person):
 
         # Unset the UID from the User Property
         user.setMemberProperties({KEY: ""})
-        logger.info("Unlinked Contact UID from User {}".format(user.getProperty(KEY)))
+        logger.info("Unlinked Contact UID from User {}".format(user.getProperty(KEY, "")))
         # Unset the Username
         self.setUsername(None)
         # Unset the Email

--- a/bika/lims/content/contact.py
+++ b/bika/lims/content/contact.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # This file is part of Bika LIMS
 #
 # Copyright 2011-2016 by it's authors.
@@ -5,54 +7,56 @@
 
 """The contact person at an organisation.
 """
-from AccessControl import ClassSecurityInfo
-from AccessControl.Permissions import manage_users
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.Archetypes.public import *
-from Products.CMFCore import permissions
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import safe_unicode
-from bika.lims.config import ManageClients, PROJECTNAME
-from bika.lims.content.person import Person
-from bika.lims import PMF, bikaMessageFactory as _
-from bika.lims.interfaces import IContact
-from zope.component import getAdapters
-from zope.interface import implements
-from bika.lims.utils import isActive
-from bika.lims.vocabularies import CustomPubPrefVocabularyFactory
+import types
 
-schema = Person.schema.copy() + Schema((
-    LinesField('PublicationPreference',
-        vocabulary_factory = 'bika.lims.vocabularies.CustomPubPrefVocabularyFactory',
-        schemata = 'Publication preference',
-        widget = MultiSelectionWidget(
-            label=_("Publication preference"),
-        ),
-    ),
-    BooleanField('AttachmentsPermitted',
-        default = False,
-        schemata = 'Publication preference',
-        widget = BooleanWidget(
-            label=_("Results attachments permitted"),
-            description = _(
-                "File attachments to results, e.g. microscope "
-                "photos, will be included in emails to recipients "
-                "if this option is enabled")
-        ),
-    ),
-    ReferenceField('CCContact',
-        schemata = 'Publication preference',
-        vocabulary = 'getContacts',
-        multiValued = 1,
-        allowed_types = ('Contact',),
-        relationship = 'ContactContact',
-        widget = ReferenceWidget(
-            checkbox_bound = 0,
-            label=_("Contacts to CC"),
-        ),
-    ),
+from AccessControl import ClassSecurityInfo
+
+from Products.Archetypes import atapi
+from Products.CMFPlone.utils import safe_unicode
+from Products.Archetypes.utils import DisplayList
+
+from zope.interface import implements
+
+from plone import api
+
+from bika.lims.utils import isActive
+from bika.lims.interfaces import IContact
+from bika.lims.content.person import Person
+from bika.lims.config import PROJECTNAME
+from bika.lims.config import ManageClients
+from bika.lims import logger
+from bika.lims import bikaMessageFactory as _
+
+
+schema = Person.schema.copy() + atapi.Schema((
+    atapi.LinesField('PublicationPreference',
+                     vocabulary_factory='bika.lims.vocabularies.CustomPubPrefVocabularyFactory',
+                     schemata='Publication preference',
+                     widget=atapi.MultiSelectionWidget(
+                         label=_("Publication preference"),
+                     )),
+    atapi.BooleanField('AttachmentsPermitted',
+                       default=False,
+                       schemata='Publication preference',
+                       widget=atapi.BooleanWidget(
+                           label=_("Results attachments permitted"),
+                           description=_(
+                               "File attachments to results, e.g. microscope "
+                               "photos, will be included in emails to recipients "
+                               "if this option is enabled")
+                       )),
+    atapi.ReferenceField('CCContact',
+                         schemata='Publication preference',
+                         vocabulary='getContacts',
+                         multiValued=1,
+                         allowed_types=('Contact',),
+                         relationship='ContactContact',
+                         widget=atapi.ReferenceWidget(
+                             checkbox_bound=0,
+                             label=_("Contacts to CC"),
+                         )),
 ))
+
 
 schema['JobTitle'].schemata = 'default'
 schema['Department'].schemata = 'default'
@@ -61,26 +65,84 @@ schema['title'].required = 0
 schema['title'].widget.visible = False
 schema.moveField('CCContact', before='AttachmentsPermitted')
 
+
 class Contact(Person):
+    """A Contact of a Client which can be linked to a System User
+    """
     implements(IContact)
+
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema
-
     _at_rename_after_creation = True
+
     def _renameAfterCreation(self, check_auto_id=False):
         from bika.lims.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def Title(self):
-        """ Return the contact's Fullname as title """
+        """Return the contact's Fullname as title
+        """
         return safe_unicode(self.getFullname()).encode('utf-8')
+
+    security.declareProtected(ManageClients, 'getUser')
+    def getUser(self):
+        """Returns the linked Plone User or None
+        """
+        username = self.getUsername()
+        if not username:
+            return None
+        user = api.user.get(userid=username)
+        return user
+
+    security.declareProtected(ManageClients, 'getUser')
+    def setUser(self, user_or_username):
+        """Link the user to the Contact
+        """
+        user = None
+        userid = None
+
+        # Handle User IDs (strings)
+        if isinstance(user_or_username, types.StringTypes):
+            userid = user_or_username
+            user = api.user.get(userid)
+        # Handle User Objects (MemberData/PloneUser)
+        if hasattr(user_or_username, "getId"):
+            userid = user_or_username.getId()
+            user = user_or_username
+
+        # Not a valid user
+        if user is None:
+            return False
+
+        # Set the Username
+        self.setUsername(userid)
+        return True
+
+    security.declareProtected(ManageClients, 'unlinkUser')
+    def unlinkUser(self, delete=False):
+        """Unlink the user to the Contact
+        """
+        userid = self.getUsername()
+        if self.hasUser():
+            logger.debug("Unlinking User '{}' from Contact '{}'".format(
+                userid, self.Title()))
+            self.setUsername(None)
+            # Also remove the Plone User (caution)
+            if delete:
+                logger.debug("Removing Plone User '{}'".format(userid))
+                api.user.delete(username=userid)
+            return True
+        return False
 
     security.declareProtected(ManageClients, 'hasUser')
     def hasUser(self):
-        """ check if contact has user """
-        return self.portal_membership.getMemberById(
-            self.getUsername()) is not None
+        """Check if Contact has a linked a System User
+        """
+        user = self.getUser()
+        if user is None:
+            return False
+        return True
 
     def getContacts(self, dl=True):
         pairs = []
@@ -94,6 +156,6 @@ class Contact(Person):
         return dl and DisplayList(pairs) or objects
 
     def getParentUID(self):
-        return self.aq_parent.UID();
+        return self.aq_parent.UID()
 
 atapi.registerType(Contact, PROJECTNAME)

--- a/bika/lims/content/contact.py
+++ b/bika/lims/content/contact.py
@@ -15,9 +15,8 @@ from Products.Archetypes import atapi
 from Products.CMFPlone.utils import safe_unicode
 from Products.Archetypes.utils import DisplayList
 
-from zope.interface import implements
-
 from plone import api
+from zope.interface import implements
 
 from bika.lims.utils import isActive
 from bika.lims.interfaces import IContact
@@ -73,9 +72,9 @@ class Contact(Person):
     """
     implements(IContact)
 
-    security = ClassSecurityInfo()
-    displayContentsTab = False
     schema = schema
+    displayContentsTab = False
+    security = ClassSecurityInfo()
     _at_rename_after_creation = True
 
     @classmethod
@@ -85,7 +84,8 @@ class Contact(Person):
 
         # Check if the User is linked already
         pc = api.portal.get_tool("portal_catalog")
-        contacts = pc(portal_type="Contact", getUsername=username)
+        contacts = pc(portal_type=cls.portal_type,
+                      getUsername=username)
 
         # No Contact assigned to this username
         if len(contacts) == 0:
@@ -212,7 +212,7 @@ class Contact(Person):
         KEY = "linked_contact_uid"
 
         username = user.getId()
-        contact = Contact.getContactByUsername(username)
+        contact = self.getContactByUsername(username)
 
         # User is linked to another contact (fix in UI)
         if contact and contact.UID() != self.UID():

--- a/bika/lims/content/labcontact.py
+++ b/bika/lims/content/labcontact.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # This file is part of Bika LIMS
 #
 # Copyright 2011-2016 by it's authors.
@@ -5,59 +7,60 @@
 
 """The lab staff
 """
-from AccessControl import ClassSecurityInfo
-from AccessControl.Permissions import manage_users
-from Products.CMFCore import permissions
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import safe_unicode
-from Products.Archetypes.public import *
-from Products.Archetypes.references import HoldingReference
-from bika.lims.content.person import Person
-from bika.lims.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from zope.component import getAdapters
-from zope.interface import implements
-from bika.lims.interfaces import ILabContact
-from bika.lims.vocabularies import CustomPubPrefVocabularyFactory
 import sys
 
-schema = Person.schema.copy() + Schema((
-    LinesField('PublicationPreference',
-        vocabulary_factory = 'bika.lims.vocabularies.CustomPubPrefVocabularyFactory',
-        default = 'email',
-        schemata = 'Publication preference',
-        widget = MultiSelectionWidget(
-            label=_("Publication preference"),
-        ),
-    ),
-    ImageField('Signature',
-        widget = ImageWidget(
-            label=_("Signature"),
-            description = _(
-                "Upload a scanned signature to be used on printed analysis "
-                "results reports. Ideal size is 250 pixels wide by 150 high"),
-        ),
-    ),
-    ReferenceField('Department',
-        required = 0,
-        vocabulary_display_path_bound = sys.maxint,
-        allowed_types = ('Department',),
-        relationship = 'LabContactDepartment',
-        vocabulary = 'getDepartments',
-        referenceClass = HoldingReference,
-        widget = ReferenceWidget(
-            checkbox_bound = 0,
-            label=_("Department"),
-            description=_("The laboratory department"),
-        ),
-    ),
-    ComputedField('DepartmentTitle',
-        expression = "context.getDepartment() and context.getDepartment().Title() or ''",
-        widget = ComputedWidget(
-            visible = False,
-        ),
-    ),
+from AccessControl import ClassSecurityInfo
+
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
+
+from Products.Archetypes import atapi
+from Products.Archetypes.references import HoldingReference
+from Products.Archetypes.utils import DisplayList
+
+from plone import api
+from zope.interface import implements
+
+from bika.lims.config import PROJECTNAME
+from bika.lims.content.person import Person
+from bika.lims.content.contact import Contact
+from bika.lims.interfaces import ILabContact
+from bika.lims import logger
+from bika.lims import bikaMessageFactory as _
+
+
+schema = Person.schema.copy() + atapi.Schema((
+    atapi.LinesField('PublicationPreference',
+                     vocabulary_factory='bika.lims.vocabularies.CustomPubPrefVocabularyFactory',
+                     default='email',
+                     schemata='Publication preference',
+                     widget=atapi.MultiSelectionWidget(
+                         label=_("Publication preference"),
+                     )),
+    atapi.ImageField('Signature',
+                     widget=atapi.ImageWidget(
+                         label=_("Signature"),
+                         description=_(
+                             "Upload a scanned signature to be used on printed analysis "
+                             "results reports. Ideal size is 250 pixels wide by 150 high"),
+                     )),
+    atapi.ReferenceField('Department',
+                         required=0,
+                         vocabulary_display_path_bound=sys.maxint,
+                         allowed_types=('Department',),
+                         relationship='LabContactDepartment',
+                         vocabulary='getDepartments',
+                         referenceClass=HoldingReference,
+                         widget=atapi.ReferenceWidget(
+                             checkbox_bound=0,
+                             label=_("Department"),
+                             description=_("The laboratory department"),
+                         )),
+    atapi.ComputedField('DepartmentTitle',
+                        expression="context.getDepartment() and context.getDepartment().Title() or ''",
+                        widget=atapi.ComputedWidget(
+                            visible=False,
+                        )),
 ))
 
 schema['JobTitle'].schemata = 'default'
@@ -65,35 +68,34 @@ schema['JobTitle'].schemata = 'default'
 schema['title'].required = 0
 schema['title'].widget.visible = False
 
-class LabContact(Person):
-    security = ClassSecurityInfo()
-    displayContentsTab = False
-    schema = schema
+
+class LabContact(Contact):
+    """A Lab Contact, which can be linked to a System User
+    """
     implements(ILabContact)
 
+    schema = schema
+    displayContentsTab = False
+    security = ClassSecurityInfo()
     _at_rename_after_creation = True
-    def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
-        renameAfterCreation(self)
 
     def Title(self):
         """ Return the contact's Fullname as title """
         return safe_unicode(self.getFullname()).encode('utf-8')
 
-    def hasUser(self):
-        """ check if contact has user """
-        return self.portal_membership.getMemberById(
-            self.getUsername()) is not None
-
     def getDepartments(self):
         bsc = getToolByName(self, 'bika_setup_catalog')
-        items = [('','')] + [(o.UID, o.Title) for o in
-                               bsc(portal_type='Department',
-                                   inactive_state = 'active')]
+        items = [('', '')] + [(o.UID, o.Title) for o in
+                              bsc(portal_type='Department',
+                                  inactive_state='active')]
         o = self.getDepartment()
         if o and o.UID() not in [i[0] for i in items]:
             items.append((o.UID(), o.Title()))
-        items.sort(lambda x,y: cmp(x[1], y[1]))
+        items.sort(lambda x, y: cmp(x[1], y[1]))
         return DisplayList(list(items))
 
-registerType(LabContact, PROJECTNAME)
+    def _renameAfterCreation(self, check_auto_id=False):
+        from bika.lims.idserver import renameAfterCreation
+        renameAfterCreation(self)
+
+atapi.registerType(LabContact, PROJECTNAME)

--- a/bika/lims/skins/bika/logged_in.cpy
+++ b/bika/lims/skins/bika/logged_in.cpy
@@ -29,16 +29,15 @@ if membership_tool.isAnonymousUser():
 
 member = membership_tool.getAuthenticatedMember()
 
-# Disable logins for deactivated Contacts
-linked_contact_uid = member.getProperty('linked_contact_uid', '')
-if linked_contact_uid:
-    catalog = getToolByName(context, "portal_catalog")
-    results = catalog(UID=linked_contact_uid)
-    if len(results) == 1:
-        contact = results[0].getObject()
-        if not contact.isActive():
-            context.plone_utils.addPortalMessage(_(u'Login failed. Your Login has been deactivated. Please contact the Lab for further information.'), 'error')
-            return state.set(status='failure')
+username = member.getId()
+catalog = getToolByName(context, "portal_catalog")
+contacts = catalog(portal_type="Contact", getUsername=username)
+# How to proceed if the User is assigned to multiple Contacts?
+if len(contacts) > 0:
+    contact = contacts[0].getObject()
+    if not contact.isActive():
+        context.plone_utils.addPortalMessage(_(u'Login failed. Your Login has been deactivated. Please contact the Lab for further information.'), 'error')
+        return state.set(status='failure')
 
 login_time = member.getProperty('login_time', '2000/01/01')
 initial_login = int(str(login_time) == '2000/01/01')

--- a/bika/lims/skins/bika/logged_in.cpy
+++ b/bika/lims/skins/bika/logged_in.cpy
@@ -29,12 +29,19 @@ if membership_tool.isAnonymousUser():
 
 member = membership_tool.getAuthenticatedMember()
 
+# https://jira.bikalabs.com/browse/LIMS-2455
 username = member.getId()
 catalog = getToolByName(context, "portal_catalog")
-contacts = catalog(portal_type="Contact", getUsername=username)
-# How to proceed if the User is assigned to multiple Contacts?
-if len(contacts) > 0:
-    contact = contacts[0].getObject()
+contacts = catalog(portal_type=["Contact", "LabContact" ],
+                   getUsername=username)
+if len(contacts) > 1:
+    # This should not happen!
+    logger.error("User {} is linked to multiple Contacts!")
+    context.plone_utils.addPortalMessage(_(u'Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information.'), 'error')
+    return state.set(status='failure')
+for contact in contacts:
+    contact = contact.getObject()
+    # Deny login if the linked Contact/LabContact is not active
     if not contact.isActive():
         context.plone_utils.addPortalMessage(_(u'Login failed. Your Login has been deactivated. Please contact the Lab for further information.'), 'error')
         return state.set(status='failure')

--- a/bika/lims/skins/bika/logged_in.cpy
+++ b/bika/lims/skins/bika/logged_in.cpy
@@ -28,6 +28,18 @@ if membership_tool.isAnonymousUser():
     return state.set(status='failure')
 
 member = membership_tool.getAuthenticatedMember()
+
+# Disable logins for deactivated Contacts
+linked_contact_uid = member.getProperty('linked_contact_uid', '')
+if linked_contact_uid:
+    catalog = getToolByName(context, "portal_catalog")
+    results = catalog(UID=linked_contact_uid)
+    if len(results) == 1:
+        contact = results[0].getObject()
+        if not contact.isActive():
+            context.plone_utils.addPortalMessage(_(u'Login failed. Your Login has been deactivated. Please contact the Lab for further information.'), 'error')
+            return state.set(status='failure')
+
 login_time = member.getProperty('login_time', '2000/01/01')
 initial_login = int(str(login_time) == '2000/01/01')
 state.set(initial_login=initial_login)

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+LIMS-2455: Contact/Login Linkage Behavior
 LIMS-2447: getDatePublished index not indexed correctly at time of AR publication
 LIMS-2404: AR list in batches permitted sampling without Sampler and Sampling date provided
 LIMS-2380: ARs are created in correct order (order of columns in ar-create form)


### PR DESCRIPTION
## Description

System Users can be assigned to a `Contact` or `LabContact`. The `login_form` allows now to *link* or *unlink* an existing User via a small search form or create a new user, which will be automatically linked to the (Lab)Contact.
If the `Contact` or `LabContact` is deactivated and has a linked User, the User cannot log into the system anymore and unlinking the user from the (Lab)Contact is disabled.

See: https://jira.bikalabs.com/browse/LIMS-2455
