### PR TITLE
LIMS-2341: Cleanup and format default Multi-AR COA

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -19,7 +19,6 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.Utils import formataddr
 from operator import itemgetter
-from os.path import join
 from plone.registry.interfaces import IRegistry
 from plone.resource.utils import iterDirectoriesOfType, queryResourceDirectory
 from Products.CMFCore.utils import getToolByName
@@ -29,13 +28,15 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from smtplib import SMTPServerDisconnected, SMTPRecipientsRefused
 from zope.component import getAdapters, getUtility
 
+from plone.registry import Record
+from plone.registry import field
+from plone import api
+
 import App
-import cgi
-import glob, os, sys, traceback
-import Globals
+import os, traceback
 import re
 import tempfile
-import urllib2
+
 
 class AnalysisRequestPublishView(BrowserView):
     template = ViewPageTemplateFile("templates/analysisrequest_publish.pt")
@@ -49,12 +50,34 @@ class AnalysisRequestPublishView(BrowserView):
         super(AnalysisRequestPublishView, self).__init__(context, request)
         self._publish = publish
         self._ars = [self.context]
+        # Simple caching hack.  Various templates can allow these functions
+        # to be called many thousands of times for relatively simple reports.
+        # To prevent bad code from causing this, we cache all analysis data
+        # here.
+        self._cache = {
+            '_analysis_data': {},
+            '_qcanalyses_data': {},
+            '_ar_data': {}
+        }
 
     @property
     def _DEFAULT_TEMPLATE(self):
         registry = getUtility(IRegistry)
         return registry.get(
             'bika.lims.analysisrequest.default_arreport_template', 'default.pt')
+
+    def next_certificate_number(self):
+        """Get a new certificate id.  These are throwaway IDs, until the
+        publication is actually done.  So each preview gives us a new ID.
+        """
+        key = 'bika.lims.current_coa_number'
+        registry = getUtility(IRegistry)
+        if key not in registry:
+            registry.records[key] = \
+                Record(field.Int(title=u"Current COA number"), 0)
+        val = api.portal.get_registry_record(key) + 1
+        api.portal.set_registry_record(key, val)
+        return "%05d"%int(val)
 
     def __call__(self):
         if self.context.portal_type == 'AnalysisRequest':
@@ -78,6 +101,9 @@ class AnalysisRequestPublishView(BrowserView):
             else:
                 groups[idclient].append(ar)
         self._arsbyclient = [group for group in groups.values()]
+
+        # Report may want to print current date
+        self.current_date = self.ulocalized_time(DateTime(), long_format=True)
 
         # Do publish?
         if self.request.form.get('publish', '0') == '1':
@@ -245,6 +271,8 @@ class AnalysisRequestPublishView(BrowserView):
         """ Creates an ar dict, accessible from the view and from each
             specific template.
         """
+        if ar.UID() in self._cache['_ar_data']:
+            return self._cache['_ar_data'][ar.UID()]
         data = {'obj': ar,
                 'id': ar.getRequestID(),
                 'client_order_num': ar.getClientOrderNumber(),
@@ -255,7 +283,6 @@ class AnalysisRequestPublishView(BrowserView):
                 'report_drymatter': ar.getReportDryMatter(),
                 'invoice_exclude': ar.getInvoiceExclude(),
                 'date_received': self.ulocalized_time(ar.getDateReceived(), long_format=1),
-                'remarks': ar.getRemarks(),
                 'member_discount': ar.getMemberDiscount(),
                 'date_sampled': self.ulocalized_time(
                     ar.getDateSampled(), long_format=1),
@@ -357,6 +384,7 @@ class AnalysisRequestPublishView(BrowserView):
             ri[dept.Title()] = ar.getResultsInterpretationByDepartment(dept)
         data['resultsinterpretationdepts'] = ri
 
+        self._cache['_ar_data'][ar.UID()] = data
         return data
 
     def _batch_data(self, ar):
@@ -450,24 +478,28 @@ class AnalysisRequestPublishView(BrowserView):
                     'url': samplepoint.absolute_url()}
         return data
 
+    def format_address(self, address):
+        if address:
+            _keys = ['address', 'city', 'district', 'state', 'zip', 'country']
+            _list = ["<div>%s</div>" % address.get(v) for v in _keys
+                     if address.get(v)]
+            return ''.join(_list)
+        return ''
+
+    def _lab_address(self, lab):
+        lab_address = lab.getPostalAddress() \
+                      or lab.getBillingAddress() \
+                      or lab.getPhysicalAddress()
+        return self.format_address(lab_address)
+
     def _lab_data(self):
         portal = self.context.portal_url.getPortalObject()
         lab = self.context.bika_setup.laboratory
-        lab_address = lab.getPostalAddress() \
-                        or lab.getBillingAddress() \
-                        or lab.getPhysicalAddress()
-        if lab_address:
-            _keys = ['address', 'city', 'state', 'zip', 'country']
-            _list = ["<div>%s</div>" % lab_address.get(v) for v in _keys
-                     if lab_address.get(v)]
-            lab_address = "".join(_list)
-        else:
-            lab_address = ''
 
         return {'obj': lab,
                 'title': to_utf8(lab.Title()),
                 'url': to_utf8(lab.getLabURL()),
-                'address': to_utf8(lab_address),
+                'address': to_utf8(self._lab_address(lab)),
                 'confidence': lab.getConfidence(),
                 'accredited': lab.getLaboratoryAccredited(),
                 'accreditation_body': to_utf8(lab.getAccreditationBody()),
@@ -484,6 +516,17 @@ class AnalysisRequestPublishView(BrowserView):
                     'pubpref': contact.getPublicationPreference()}
         return data
 
+    def _client_address(self, client):
+        client_address = client.getPostalAddress()
+        if not client_address:
+            # Data from the first contact
+            contact = self.getAnalysisRequest().getContact()
+            if contact and contact.getBillingAddress():
+                client_address = contact.getBillingAddress()
+            elif contact and contact.getPhysicalAddress():
+                client_address = contact.getPhysicalAddress()
+        return self.format_address(client_address)
+
     def _client_data(self, ar):
         data = {}
         client = ar.aq_parent
@@ -495,23 +538,7 @@ class AnalysisRequestPublishView(BrowserView):
             data['phone'] = to_utf8(client.getPhone())
             data['fax'] = to_utf8(client.getFax())
 
-            client_address = client.getPostalAddress()
-            if not client_address:
-                # Data from the first contact
-                contact = self.getAnalysisRequest().getContact()
-                if contact and contact.getBillingAddress():
-                    client_address = contact.getBillingAddress()
-                elif contact and contact.getPhysicalAddress():
-                    client_address = contact.getPhysicalAddress()
-
-            if client_address:
-                _keys = ['address', 'city', 'state', 'zip', 'country']
-                _list = ["<div>%s</div>" % client_address.get(v) for v in _keys
-                         if client_address.get(v)]
-                client_address = "".join(_list)
-            else:
-                client_address = ''
-            data['address'] = to_utf8(client_address)
+            data['address'] = to_utf8(self._client_address(client))
         return data
 
     def _specs_data(self, ar):
@@ -571,6 +598,9 @@ class AnalysisRequestPublishView(BrowserView):
         return analyses
 
     def _analysis_data(self, analysis, decimalmark=None):
+        if analysis.UID() in self._cache['_analysis_data']:
+            return self._cache['_analysis_data'][analysis.UID()]
+
         keyword = analysis.getKeyword()
         service = analysis.getService()
         andict = {'obj': analysis,
@@ -656,9 +686,12 @@ class AnalysisRequestPublishView(BrowserView):
                 if ret and ret['out_of_range']:
                     andict['outofrange'] = True
                     break
+        self._cache['_analysis_data'][analysis.UID()]  = andict
         return andict
 
     def _qcanalyses_data(self, ar, analysis_states=['verified', 'published']):
+        if ar.UID() in self._cache['_qcanalyses_data']:
+            return self._cache['_qcanalyses_data'][ar.UID()]
         analyses = []
         batch = ar.getBatch()
         workflow = getToolByName(self.context, 'portal_workflow')
@@ -673,6 +706,7 @@ class AnalysisRequestPublishView(BrowserView):
 
             analyses.append(andict)
         analyses.sort(lambda x, y: cmp(x.get('title').lower(), y.get('title').lower()))
+        self._cache['_qcanalyses_data'][ar.UID()] = analyses
         return analyses
 
     def _reporter_data(self, ar):
@@ -718,7 +752,6 @@ class AnalysisRequestPublishView(BrowserView):
             managers['dict'][mngr]['departments'] = final_depts
 
         return managers
-
 
     def localise_images(self, htmlreport):
         """WeasyPrint will attempt to retrieve attachments directly from the URL
@@ -931,7 +964,6 @@ class AnalysisRequestPublishView(BrowserView):
         results_html = safe_unicode(self.template()).encode('utf-8')
         return self.publishFromHTML(results_html)
 
-
     def get_recipients(self, ar):
         """ Returns a list with the recipients and all its publication prefs
         """
@@ -1061,12 +1093,14 @@ class AnalysisRequestPublishView(BrowserView):
                     analyses[cat] = {
                         service.title: {
                             'service': service,
+                            'accredited': service.getAccredited(),
                             'ars': {ar.id: an.getFormattedResult()}
                         }
                     }
                 elif service.title not in analyses[cat]:
                     analyses[cat][service.title] = {
                         'service': service,
+                        'accredited': service.getAccredited(),
                         'ars': {ar.id: an.getFormattedResult()}
                     }
                 else:

--- a/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.css
+++ b/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.css
@@ -2,73 +2,141 @@
  * Do not use margins, use padding instead
  */
 
-#report {
-    font: 9pt Arial, Verdana, serif;
+@page {
 }
 
-#report h1 { font-size:1.4em; }
-#report h2 { font-size:1.2em; }
-#report h3 { font-size:1.1em; }
+#report {
+    font: 8pt Arial, Verdana, serif;
+}
 
-#report h1,
-#report h2,
-#report h3 {
+#report h1 {
+    font-size:1.4em;
+    font-weight:bold;
+}
+
+#report h2 {
+    font-size:1.2em;
     font-weight:bold;
     padding-bottom:5px !important;
 }
 
-#report table {
-    width: 100%;
+#report h3 {
+    font-size:1.1em;
+    font-weight:bold;
+    padding-bottom:5px !important;
 }
 
-#report table tr td,
-#report table tr th {
-    text-align:left;
-    vertical-align:top;
+.page-header {
+    height: 76px;
 }
+
+#section-info {
+    line-height:125% !important;
+}
+
+#section-info-heading {
+    height:2em;
+    text-align:center !important;
+    vertical-align:center;
+}
+
+#discreeter div{
+  margin-top:3px;
+  line-height: 125% !important;
+}
+
+#discreeter-info {
+    color:#555;
+}
+
+.accredited-ico {
+    height:1.1em;
+    vertical-align:middle;
+}
+
 #report .label {
     font-weight:bold;
     padding-right: 10px;
+    text-align: left;
+    vertical-align: top;
 }
 #report .outofrange,
 #report .outofrange a {
     font-weight:bold;
     color:#d40000;
 }
-#report .units,
-#report .units sub,
-#report .units sup {
-    color:#777;
-    font-weight:normal;
-    font-style:italic;
-}
-#report .units sub,
-#report .units sup {
-    font-size:7pt;
-}
 #report .page-footer table {
     border-top: 1px solid #aaaaaa;
     padding: 5px 0;
     width: 100%;
 }
-#report #ar-grid th {
-    padding: 5px 5px 5px 0;
+
+.ar_table {
+    padding-top:10px;
+    font-size: 82.5%;
+    border-top:1px solid #cdcdcd;
+    border-left:1px solid #cdcdcd;
 }
-#report #ar-grid td {
-  border:1px solid #cdcdcd;
-  padding:3px;
+.ar_table .header_th {
+    font-weight:bold;
+    padding: 2px 2px 2px 0;
 }
-#report #ar-grid td.blank-row {
-  border: 0 none;
-  padding: 10px;
+.ar_table .header_td {
+    text-align: center;
+    font-weight:bold;
+    padding:2px;
 }
-#report #ar-grid td.sampleid,
-#report #ar-grid td.sampletype,
-#report #ar-grid td.samplepoint,
-#report #ar-grid td.result {
-  text-align:center;
+.ar_table .th {
+    background: #eeeeee;
+    color: #444444;
+    padding:1px;
+    border-bottom:1px solid #cdcdcd;
+    border-right:1px solid #cdcdcd;
 }
-#report #ar-grid td.sampleid {
-  font-weight:bold;
-  text-align:center;
+.ar_table .td {
+    padding:1px;
+    border-bottom:1px solid #cdcdcd;
+    border-right:1px solid #cdcdcd;
 }
+.cat_title {
+    background: #dddddd;
+    color: #444444;
+    padding:2px 0px 2px 0px;
+    margin-top:7px;
+}
+
+.ar_table .unit,
+.ar_table .unit sub,
+.ar_table .unit sup {
+    color:#777;
+    font-weight:normal;
+    font-style:italic;
+    font-size:7pt;
+}
+
+div.resultsinterpretation {
+    border: 1px solid #cdcdcd;
+}
+
+div.resultsinterpretation_heading {
+    font-weight:bold;
+    background: #dddddd;
+    color: #444444;
+    margin-top:7px;
+    padding:2px 0px 2px 0px;
+    font-size:1.2em;
+}
+
+
+/* this is to reproduce table-like structure
+   for the sake of table-less layout. */
+.table { display:table; table-layout:fixed; width:100%; }
+.row { display:table-row; }
+.th { display:table-cell; font-weight:bold; }
+.td { display:table-cell; }
+/* this is where the colspan tricks works. */
+/* below is for visual recognition test purposes only. */
+.red { background:red; }
+.blue { background:blue; }
+.green { background:green; }
+.black { background:black; }

--- a/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
@@ -1,190 +1,317 @@
-<!--
-    Default Analysis Request results template for Bika LIMS
+<tal:comment replace="nothing">
+    Print COA for a set of analysisrequests.
 
-    All data is available using the analysisrequest dictionary.
-    Example for accessing and displaying data:
+    The filename starts with "multi" indicates this report is formatted
+    print multiple ARs.
+</tal:comment>
 
-    <p tal:content="python:analysisrequest['laboratory']['title']"></p>
-
-    or
-
-    <p tal:content="analysisrequest/laboratory/title"></p>
-
-    Take a look to the documentation for more information about
-    available data and fields.
-    https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates
-
--->
-<tal:report tal:define="num_ars_per_page python:4;
+<tal:report tal:define="num_ars_per_page python:5;
                         argroup python:view.getAnalysisRequestGroup();
-                        arspage python:[argroup[i:i+num_ars_per_page] for i in range(0,len(argroup),num_ars_per_page)];">
+                        arspage python:[argroup[i:i+num_ars_per_page] for i in range(0,len(argroup),num_ars_per_page)];
+                        coanr python:view.next_certificate_number();">
 
-  <tal:page_iter repeat="ars arspage">
-  <tal:page tal:define="
-      firstar         python:ars[0];
-      analysisrequest python:view.getAnalysisRequest(firstar);
-      client          analysisrequest/client;
-      contact         analysisrequest/contact;
-      laboratory      analysisrequest/laboratory;
-      portal          analysisrequest/portal;
-      showqcanalyses  python:view.isQCAnalysesVisible();
-      remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();">
+    <!-- Address and Lab info, displayed only on first page. -->
+    <div id="section-info"
+         tal:define="firstar         python:arspage[0][0];
+                     analysisrequest python:view.getAnalysisRequest(firstar);
+                     portal          analysisrequest/portal;
+                     client          python:analysisrequest['client']['obj'];
+                     contact         python:analysisrequest['contact']['obj'];
+                     lab             python:portal['obj'].bika_setup.laboratory;
+                     showqcanalyses  python:view.isQCAnalysesVisible();
+                     remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();">
+        <table width="100%" cellpadding="0" cellspacing="0">
+            <tr>
+                <td colspan="2" id="section-info-heading" i18n:translate="section-info-heading">
+                    <h1>CERTIFICATE OF ANALYSIS</h1>
+                </td>
+            </tr>
+        </table>
+        <hr size="1"/>
+        <table width="100%" cellpadding="0" cellspacing="0">
+            <tr>
+                <td>
+                    <!-- Client -->
+                    <table>
+                        <tr>
+                            <th i18n:translate="" class="label">Client</th>
+                            <td tal:content="python:client.Title()"/>
+                        </tr>
+                        <tr>
+                            <th i18n:translate="" class="label">Contact</th>
+                            <td tal:content="python:contact.getFullname()"/>
+                        </tr>
+                        <tr>
+                            <th i18n:translate="" class="label">Email</th>
+                            <td id="client-email">
+                                <a tal:content="python:contact.getEmailAddress()"
+                                   tal:attributes="url python:'mailto:%s' % contact.getEmailAddress()"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th i18n:translate="" class="label">Telephone</th>
+                            <td tal:content="structure python: client.getPhone()"/>
+                        </tr>
+                        <tr>
+                            <th i18n:translate="" class="label">Address</th>
+                            <td tal:content="structure python:view._client_address(client)"/>
+                        </tr>
+                    </table>
+                </td>
+                <td>
+                    <!-- Laboratory -->
+                    <table>
+                        <tr>
+                            <th i18n:translate="" class="label">
+                                Laboratory
+                            </th>
+                            <td tal:content="python: lab.Title()"/>
+                        </tr>
+                        <tr>
+                            <th i18n:translate="" class="label">Email
+                            </th>
+                            <td>
+                                <a tal:content="python:lab.getEmailAddress()"
+                                   tal:attributes="url python:'mailto:%s' % lab.getEmailAddress()"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th i18n:translate="" class="label">
+                                Telephone
+                            </th>
+                            <td tal:content="structure python: lab.getPhone()"/>
+                        </tr>
+                        <tr>
+                            <th i18n:translate="" class="label">
+                                Address
+                            </th>
+                            <td tal:content="structure python:view._lab_address(lab)"/>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+        <hr size="1"/>
+        <table width="100%" cellpadding="0" cellspacing="0">
+            <tr>
+                <th i18n:translate="" class="label">Report Date</th>
+                <td tal:content="structure view/current_date"/>
+            </tr>
+            <tr>
+                <th i18n:translate="" class="label">Number of samples</th>
+                <td tal:content="structure python:len(argroup)"/>
+            </tr>
+            <tr>
+                <th i18n:translate="" class="label">Certificate Number
+                </th>
+                <td tal:content="structure coanr"/>
+            </tr>
+        </table>
 
-  <!--
-      Page Header
-      A div element with the class "page-header" will be placed on the
-      top of the report, within the top margin area. This element
-      will be displayed on each page.
+        <hr size="1"/>
 
-      Page numbering
-      For the number of page, use the "page-current-num" class.
-      For the total count, use the "page-total-count" class.
-  -->
-  <div id="section-header" class="page-header">
-    <div id='lab-logo'>
-      <a tal:attributes="href laboratory/url">
-          <img tal:attributes="src laboratory/logo"/>
-      </a>
+
+        <!-- Discreeter section -->
+        <div class="discreeter" id="discreeter-info">
+            <div i18n:translate="">
+                This report supersedes any previous report for the samples listed here.
+            </div>
+            <div i18n:translate="">
+                Analysis results relate only to the samples as they were received.
+            </div>
+            <div i18n:translate="">
+                This document shall not be reproduced except in full, without the written approval of
+                <tal:block replace="python:lab.Title()" i18n:name="name_lab"/>.
+            </div>
+            <div tal:condition="python:lab.getConfidence()" i18n:translate="">
+                Test results are at a <tal:block replace="python:lab.getConfidence()" i18n:name="lab_confidence"/>% confidence level.
+            </div>
+            <div tal:condition="python:lab.getLaboratoryAccredited()" i18n:translate="">
+                Methods included in the
+                <tal:block replace="python:lab.getAccreditationBody()" i18n:name="accreditation_body"/>
+                schedule of Accreditation for this Laboratory are marked with
+                <img tal:attributes='src python:portal["url"]+"/++resource++bika.lims.images/accredited.png";' class="accredited-ico"/>
+            </div>
+            <div tal:condition="python:lab.getLaboratoryAccredited()" i18n:translate="">
+                Analysis remarks are not accredited.
+            </div>
+        </div>
+
     </div>
-  </div>
 
-  <!-- Address and Lab info -->
-  <div id="section-info">
-      <table width="100%">
-          <tr>
-              <td id="lab-info">
-                  <table>
-                      <tr><td id="lab-title" tal:content='laboratory/title'></td></tr>
-                      <tr><td id="lab-address" tal:content='structure laboratory/address'></td></tr>
+    <tal:comment replace="nothing">
+        Break before first AR section.
+        Subsequent AR sections have page breaks after each one.
+    </tal:comment>
+    <div class='manual-page-break'></div>
 
-                      <tr tal:condition="laboratory/url">
-                          <td id="lab-URL">
-                              <a tal:attributes="href laboratory/url"
-                                 tal:content="laboratory/url"></a>
-                          </td>
-                      </tr>
-                  </table>
-              </td>
-          </tr>
-      </table>
-      <hr size="1"/>
-      <table width="100%" cellpadding="0" cellspacing="0">
-        <tr>
-            <td i18n:translate="" class="label">Client</td>
-            <td id="client-name" tal:content="client/name"></td>
-            <td i18n:translate="" class="label">Address</td>
-            <td id="client-address" tal:content="structure client/address"></td>
-        </tr>
-        <tr>
-            <td i18n:translate="" class="label">Client Contact</td>
-            <td id="client-contact" tal:content="python:contact.get('fullname','')"></td>
-            <td i18n:translate="" class="label">Received Date</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td i18n:translate="" class="label">Contact Email</td>
-            <td id="client-email">
-              <a tal:content="contact/email"
-                 tal:attributes="url python:'mailto:%s' % contact['email'];"></a>
-            </td>
-            <td i18n:translate="" class="label">Reporting Date</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td i18n:translate="" class="label">Contact Number</td>
-            <td></td>
-            <td i18n:translate="" class="label">Certificate Number</td>
-            <td></td>
-        </tr>
-      </table>
-      <hr size="1"/>
-  </div>
+    <tal:page_iter repeat="ars arspage">
+        <tal:page tal:define="
+            firstar         python:ars[0];
+            analysisrequest python:view.getAnalysisRequest(firstar);
+            portal          analysisrequest/portal;
+            client          python:analysisrequest['client']['obj'];
+            contact         python:analysisrequest['contact']['obj'];
+            lab             python:portal['obj'].bika_setup.laboratory;
+            showqcanalyses  python:view.isQCAnalysesVisible();
+            remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();">
 
-  <!-- Analysis Requests table -->
-  <div id="ar-grid" tal:define="transposed python:view.getAnaysisBasedTransposedMatrix(ars);">
-    <table width="100%" cellpadding="0" cellspacing="0">
-      <!-- Sample ID -->
-      <tr>
-        <th i18n:translate="" colspan="5">Sample ID</th>
-        <tal:ar repeat="ar ars">
-        <td tal:attributes="id ar/id;uid ar/UID;" class="sampleid">
-          <a tal:attributes="href python:ar.getSample().absolute_url()"
-             tal:content="python:ar.getSample().id"></a>
-        </td>
-        </tal:ar>
-      </tr>
-      <!-- Sample Type -->
-      <tr>
-        <th i18n:translate="" colspan="5">Sample Type</th>
-        <tal:ar repeat="ar ars">
-        <td class="sampletype" tal:content="python:ar.getSample().getSampleType().title"></td>
-        </tal:ar>
-      </tr>
-      <!-- Sample Point -->
-      <tr>
-        <th i18n:translate="" colspan="5">Sample Point</th>
-        <tal:ar repeat="ar ars">
-        <td class="samplepoint" tal:content="python:ar.getSample().getSamplePointTitle()"></td>
-        </tal:ar>
-      </tr>
+            <!-- This element will be displayed on each page within the top margin area. -->
+            <div id="section-header" class="page-header">
+                <div id='lab-logo'>
+                    <table style="margin:0;padding:0;width:100%" cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td width="100%">
+                                <a tal:attributes="href python: lab.getLabURL()">
+                                    <img tal:attributes="src python:portal['obj'].absolute_url() + '/logo_print.png'"/>
+                                </a>
+                            </td>
+                            <td>
+                                <img tal:attributes="src python:lab.getAccreditationBodyLogo().absolute_url()"/>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
 
-      <!-- Tests/results -->
-      <tr>
-          <td class="blank-row" tal:attributes="colspan python:len(ars)+5;"></td>
-      </tr>
-      <tr>
-        <th i18n:translate="">Category</th>
-        <th i18n:translate="">Analysis</th>
-        <th>+/-</th>
-        <th i18n:translate="">Unit</th>
-        <th i18n:translate="">Method</th>
-        <th attributes="colspan python:len(ars)" i18n:translate="">Results</th>
-      </tr>
-      <tal:cats repeat="cat python:sorted(transposed.keys())">
-      <tr>
-        <td class="category" tal:content="cat" tal:attributes="rowspan python:len(transposed[cat].keys())+1"></td>
-      </tr>
-      <tr tal:repeat="service python:sorted(transposed[cat].keys())">
-        <td class="service" tal:content="service"></td>
-        <td></td>
-        <td class="unit" tal:content="python:transposed[cat][service]['service'].getUnit()"></td>
-        <td class="method" tal:content="python:transposed[cat][service]['service'].getMethod().title if transposed[cat][service]['service'].getMethod() else ''"></td>
-        <tal:ar repeat="ar ars">
-        <td class="result" tal:content="python:transposed[cat][service]['ars'].get(ar.id,'')"></td>
-        </tal:ar>
-      </tr>
-      </tal:cats>
-    </table>
-  </div>
+            <!-- Analysis Requests table -->
+            <tal:def tal:define="transposed python:view.getAnaysisBasedTransposedMatrix(ars);
+                     cat_titles python:sorted(transposed.keys());
+                     leftcol_width python:50 + divmod(50, len(ars))[1];
+                     rightcol_width python:100 - leftcol_width;
+                     methodcol_width python:float(leftcol_width)/100*40;
+                     servicecol_width python:float(leftcol_width)/100*50;
+                     unitcol_width python:leftcol_width-(methodcol_width+servicecol_width);
+                     arcol_width python:float(rightcol_width)/len(ars);">
 
-  <!--
-      Page footer
-      A div element with the class "page-footer" will be placed in the
-      bottom of the report, within the bottom margin area. This element
-      will be displayed on each page.
+                <!-- AR Group headers -->
+                <div class="table ar_table">
+                    <div class="row">
+                        <span class="th header_th"
+                              tal:attributes="style string:width:${leftcol_width}%;;border-top:1px solid #cdcdcd;"
+                              i18n:translate="">Sample ID</span>
+                        <tal:ar repeat="ar ars">
+                            <span class="td header_td"
+                                  tal:attributes="style string:width:${arcol_width}%;;border-top:1px solid #cdcdcd;"
+                                  tal:content="python:ar.getSample().id"/>
+                        </tal:ar>
+                    </div>
+                    <div class="row">
+                        <span class="th header_th"
+                              tal:attributes="style string:width:${leftcol_width}%"
+                              i18n:translate="">Sample Type</span>
+                        <tal:ar repeat="ar ars">
+                            <span class="td header_td"
+                                  tal:attributes="style string:width:${arcol_width}%"
+                                  tal:content="python:ar.getSample().getSampleType().Title()"/>
+                        </tal:ar>
+                    </div>
+                    <div class="row">
+                        <span class="th header_th"
+                              tal:attributes="style string:width:${leftcol_width}%"
+                              i18n:translate="">Date Received</span>
+                        <tal:ar repeat="ar ars">
+                            <span class="td header_td"
+                                  tal:attributes="style string:width:${arcol_width}%"
+                                  tal:content="python:ar.getDateReceived().Date()"/>
+                        </tal:ar>
+                    </div>
+                </div>
 
-      Page numbering
-      For the number of page, use the "page-current-num" class.
-      For the total count, use the "page-total-count" class.
-  -->
-  <div class='page-footer'>
-    <table>
-      <tr>
-        <td class='footer-discreeter'>
-          <div class="page-number">Page <span class="page-current-num"></span> of <span class="page-total-count"></span></div>
-        </td>
-      </tr>
-    </table>
-  </div>
+                <!-- Category header for each category -->
+                <tal:category tal:repeat="cat_title cat_titles">
+                    <div class="cat_title" tal:content="cat_title"/>
+                    <!-- Service details for each result and results for each AR -->
+                    <div class="table ar_table">
+                        <div class="row">
+                            <span class="th"
+                                  tal:attributes="style string:width:${servicecol_width}%">Service</span>
+                            <span class="th"
+                                  tal:attributes="style string:width:${methodcol_width}%">Method</span>
+                            <span class="th"
+                                  tal:attributes="style string:width:${unitcol_width}%">Unit</span>
+                            <tal:ar repeat="ar ars">
+                                <span class="th"
+                                      tal:attributes="style string:width:${arcol_width}%">Result</span>
+                            </tal:ar>
+                        </div>
 
-  <!--
-      Manual break ("manual-page-break" css class)
-      We want to report to be splitted by the max number of ARs per page.
+                        <tal:cat_analyses tal:repeat="service_title python:sorted(transposed[cat_title].keys())">
+                            <div class="row">
+                                <span class="td service_title"
+                                      tal:attributes="style string:width:${servicecol_width}%">
+                                <span tal:content="service_title"/>
+                                <img tal:attributes='src python:portal["url"]+"/++resource++bika.lims.images/accredited.png";'
+                                     tal:condition="python:transposed[cat_title][service_title]['accredited']"
+                                     class="accredited-ico"/>
+                                </span>
+                                <span class="td method_title"
+                                      tal:attributes="style string:width:${methodcol_width}%"
+                                      tal:content="python:transposed[cat_title][service_title]['service'].getMethod().Title() if transposed[cat_title][service_title]['service'].getMethod() else ''"></span>
+                                <span class="td unit"
+                                      tal:attributes="style string:width:${unitcol_width}%"
+                                      tal:content="python:transposed[cat_title][service_title]['service'].getUnit()"></span>
+                                <tal:ar repeat="ar ars">
+                                    <span class="td result"
+                                          tal:attributes="style string:width:${arcol_width}%"
+                                          tal:content="structure python:transposed[cat_title][service_title]['ars'].get(ar.id,'')"/>
+                                </tal:ar>
+                            </div>
+                        </tal:cat_analyses>
+                    </div>
+                </tal:category>
 
-      Restart page count ("restart-page-count" css class)
-      We want the number of pages to restart after the current page
-  -->
-  <div class='manual-page-break restart-page-count'></div>
-  </tal:page>
-  </tal:page_iter>
+                <!-- Results Interpretation for all ARs in this argroup -->
+                <tal:ri_ars repeat="ar ars">
+                    <tal:ri_def define="interps python:ar.getResultsInterpretationDepts();
+                                        uc python:ar.uid_catalog"
+                                condition="interps">
+                        <div tal:repeat="interp interps" class="resultsinterpretation">
+                            <div class="resultsinterpretation_heading"
+                                 tal:condition="python:interp['uid'] == 'general'">
+                                General results interpretation for <span tal:replace="python:ar.id"/>
+                            </div>
+                            <div class="resultsinterpretation_heading"
+                                 tal:condition="python:interp['uid'] != 'general'"
+                                 tal:content="python:'Interpreted results for %s (%s)'%(ar.id, uc(UID=interp['uid'])[0].title)"></div>
+                                <span tal:content="structure python:interp['richtext']"/>
+                        </div>
+                    </tal:ri_def>
+                </tal:ri_ars>
+
+            </tal:def>
+
+            <!--
+            Page footer
+            A div element with the class "page-footer" will be placed in the
+            bottom of the report, within the bottom margin area. This element
+            will be displayed on each page.
+
+            Page numbering
+            For the number of page, use the "page-current-num" class.
+            For the total count, use the "page-total-count" class.
+            -->
+            <div class='page-footer'>
+                <table>
+                    <tr>
+                        <td class='footer-discreeter'>
+                            <div class="page-number">Page
+                                <span class="page-current-num"></span> of
+                                <span class="page-total-count"></span></div>
+                        </td>
+                        <td align="right" tal:content="coanr"></td>
+                    </tr>
+                </table>
+            </div>
+
+            <!--
+                Manual break ("manual-page-break" css class)
+                We want to report to be splitted by the max number of ARs per page.
+
+                Restart page count ("restart-page-count" css class)
+                We want the number of pages to restart after the current page
+            -->
+            <div class='manual-page-break'></div>
+        </tal:page>
+    </tal:page_iter>
 </tal:report>

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+LIMS-2341: Cleanup and format default Multi-AR COA
 LIMS-2455: Contact/Login Linkage Behavior
 LIMS-2447: getDatePublished index not indexed correctly at time of AR publication
 LIMS-2404: AR list in batches permitted sampling without Sampler and Sampling date provided


### PR DESCRIPTION
- AR result table is no longer a single diff; handles pagination much better.
- Flag accredited results with icon.
- Add results interpretation where available after each AR group.
- Cache rendered data between calls to prevent templates from duplicate access.
- Add certificate number which increments each time report is printed.
