### PR TITLE
Multi-verification of analyses, with different verification types

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -31,3 +31,4 @@ Luke Williams <luke@iquidus.co.nz>
 Manav Batra <manavbatra@outlook.com>
 Aman Arora <aman2arora2@gmail.com>
 Ramon Bartl <rb@ridingbytes.com>
+Nihadness <nmammadli@naralabs.com>

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -754,7 +754,7 @@ class AnalysesView(BikaListingView):
                 if allowed and not obj.isUserAllowedToVerify(member):
                     after_icons.append(
                         "<img src='++resource++bika.lims.images/submitted-by-current-user.png' title='%s'/>" %
-                        (t(_("Cannot verify, submitted by current user")))
+                        (t(_("Cannot verify, submitted or verified by current user before")))
                         )
                 elif allowed:
                     if obj.getSubmittedBy() == member.getUser().getId():

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -762,6 +762,13 @@ class AnalysesView(BikaListingView):
                         "<img src='++resource++bika.lims.images/warning.png' title='%s'/>" %
                         (t(_("Can verify, but submitted by current user")))
                         )
+            #If analysis Submitted and Verified by the same person, then warning icon will appear.
+            if obj.getSubmittedBy() and obj.getVerifiedBy() \
+                    and obj.getSubmittedBy() == obj.getVerifiedBy():
+                after_icons.append(
+                    "<img src='++resource++bika.lims.images/warning.png' title='%s'/>" %
+                    (t(_("Submited and verified by the same user- "+obj.getVerifiedBy())))
+                    )
 
             # add icon for assigned analyses in AR views
             if self.context.portal_type == 'AnalysisRequest':

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -763,11 +763,11 @@ class AnalysesView(BikaListingView):
                         (t(_("Can verify, but submitted by current user")))
                         )
             #If analysis Submitted and Verified by the same person, then warning icon will appear.
-            if obj.getSubmittedBy() and obj.getVerifiedBy() \
-                    and obj.getSubmittedBy() == obj.getVerifiedBy():
+            submitter=obj.getSubmittedBy()
+            if submitter and obj.wasVerifiedByUser(submitter):
                 after_icons.append(
                     "<img src='++resource++bika.lims.images/warning.png' title='%s'/>" %
-                    (t(_("Submited and verified by the same user- "+obj.getVerifiedBy())))
+                    (t(_("Submited and verified by the same user- "+ submitter)))
                     )
 
             # add icon for assigned analyses in AR views

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -217,7 +217,7 @@ class WorkflowAction:
                         success = True
                         revers = item.getNumberOfRequiredVerifications()
                         nmvers = item.getNumberOfVerifications()
-                        username=getToolByName(context,'portal_membership').getAuthenticatedMember().getUserName()
+                        username=getToolByName(self.context,'portal_membership').getAuthenticatedMember().getUserName()
                         item.addVerificator(username)
                         #item.setNumberOfVerifications(nmvers+1)
                         if revers-nmvers <= 1:

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -219,12 +219,10 @@ class WorkflowAction:
                         nmvers = item.getNumberOfVerifications()
                         username=getToolByName(self.context,'portal_membership').getAuthenticatedMember().getUserName()
                         item.addVerificator(username)
-                        #item.setNumberOfVerifications(nmvers+1)
                         if revers-nmvers <= 1:
                             success, message = doActionFor(item, action)
                             if not success:
-                                # If failed, restore to the previous number
-                                #item.setNumberOfVerifications(numvers)
+                                # If failed, remove the last verification
                                 item.deleteLastVerificator()
                     else:
                         success, message = doActionFor(item, action)

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -217,12 +217,15 @@ class WorkflowAction:
                         success = True
                         revers = item.getNumberOfRequiredVerifications()
                         nmvers = item.getNumberOfVerifications()
-                        item.setNumberOfVerifications(nmvers+1)
+                        username=getToolByName(context,'portal_membership').getAuthenticatedMember().getUserName()
+                        item.addVerificator(username)
+                        #item.setNumberOfVerifications(nmvers+1)
                         if revers-nmvers <= 1:
                             success, message = doActionFor(item, action)
                             if not success:
                                 # If failed, restore to the previous number
-                                item.setNumberOfVerifications(numvers)
+                                #item.setNumberOfVerifications(numvers)
+                                item.deleteLastVerificator()
                     else:
                         success, message = doActionFor(item, action)
                     if success:

--- a/bika/lims/browser/js/bika.lims.bikasetup.js
+++ b/bika/lims/browser/js/bika.lims.bikasetup.js
@@ -44,6 +44,17 @@ function BikaSetupEditView() {
             }
         });
 
+        if ($("select[name=NumberOfRequiredVerifications] option:selected").val() == 1) {
+            document.getElementById('archetypes-fieldname-TypeOfmultiVerification').style.display='none';
+        }
+        $('#NumberOfRequiredVerifications').change(function () {
+            if ($(this).val()>1) {
+              document.getElementById('archetypes-fieldname-TypeOfmultiVerification').style.display='block';
+            } else {
+              document.getElementById('archetypes-fieldname-TypeOfmultiVerification').style.display='none';
+            }
+        });
+
         $(restrict_useraccess).change();
     };
 
@@ -67,4 +78,3 @@ function BikaSetupEditView() {
         }
     }
 }
-

--- a/bika/lims/config.py
+++ b/bika/lims/config.py
@@ -120,3 +120,8 @@ WORKSHEET_LAYOUT_OPTIONS = DisplayList((
     ('1', _('Classic')),
     ('2', _('Transposed')),
 ))
+MULTI_VERIFICATION_TYPE = DisplayList((
+    ('self_multi_enabled', _('Allow same user to verify multiple times')),
+    ('self_multi_not_cons', _('Allow same user to verify multiple times, but not consecutively')),
+    ('self_multi_disabled', _('Disable multi-verification for the same user')),
+))

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -216,12 +216,10 @@ schema = BikaSchema.copy() + Schema((
     # NumberOfRequiredVerifications from the Analysis Service
     IntegerField('NumberOfRequiredVerifications', default=1),
 
-    # Number of verifications done for this analysis. Each time a 'verify'
-    # transition takes place, this value is updated accordingly. The
-    # transition will finally succeed when the NumberOfVerifications matches
-    # with the NumberOfRequiredVerifications. Meanwhile, the state of the
-    # object will remain in 'to_be_verified'
-    IntegerField('NumberOfVerifications', default=0),
+    # This field keeps the user_ids of members who verified this analysis.
+    # After each verification, user_id will be added end of this string
+    # seperated by comma- ',' .
+    StringField('Verificators',)
 ),
 )
 
@@ -235,6 +233,31 @@ class Analysis(BaseContent):
     def _getCatalogTool(self):
         from bika.lims.catalog import getCatalog
         return getCatalog(self)
+
+    def getNumberOfVerifications(self):
+        verificators=self.getVerificators()
+        if not verificators:
+            return 0
+        return len(verificators.split(','))
+
+    def addVerificator(self,username):
+        verificators=self.getVerificators()
+        if not verificators:
+            self.setVerificators(username)
+        else:
+            self.setVerificators(verificators.split(',').append(username).join(','))
+
+    def deleteLastVerificator(self):
+        verificators=self.getVerificators().split(',')
+        del verificators[-1]
+        self.setVerificators(verificators.join(','))
+
+    def wasVerifiedByUser(self,username):
+        verificators=self.getVerificators().split(',')
+        return username in verificators
+
+    def getLastVerificator(self):
+        return self.getVerificators().split(',')[-1]
 
     def Title(self):
         """ Return the service title as title.
@@ -1068,6 +1091,17 @@ class Analysis(BaseContent):
         if self_submitted and not selfverification:
             return False
 
+        #Checking verifiability depending on multi-verification type of bika_setup
+        if bika_setup.getNumberOfRequiredVerifications>1:
+            mv_type=self.bika_setup.getTypeOfmultiVerification()
+            #If user verified before and self_multi_disabled, then return False
+            if mv_type=='self_multi_disabled' and self.wasVerifiedByUser(username):
+                return False
+            # If user is the last verificator and multi-verification consecutively
+            # is disabled, then return False
+            elif mv_type=='self_multi_not_cons' and username==self.getLastVerificator():
+                return False
+
         # All checks pass
         return True
 
@@ -1083,22 +1117,6 @@ class Analysis(BaseContent):
             review_history = self.reverseList(review_history)
             for event in review_history:
                 if event.get("action") == "submit":
-                    return event.get("actor")
-        except WorkflowException:
-            return ''
-
-    def getVerifiedBy(self):
-        """
-        Returns the identifier of the user who verified the result if the
-        state of the current analysis is "verified" or "published"
-        :return: the user_id of the user who did the last submission of result
-        """
-        workflow = getToolByName(self, "portal_workflow")
-        try:
-            review_history = workflow.getInfoFor(self, "review_history")
-            review_history = self.reverseList(review_history)
-            for event in review_history:
-                if event.get("action") == "verify":
                     return event.get("actor")
         except WorkflowException:
             return ''

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -667,7 +667,7 @@ class Analysis(BaseContent):
         # Add interims to mapping
         for i in interims:
             if 'keyword' not in i:
-                continue;
+                continue
             try:
                 ivalue = float(i['value'])
                 mapping[i['keyword']] = ivalue

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -219,7 +219,7 @@ schema = BikaSchema.copy() + Schema((
     # This field keeps the user_ids of members who verified this analysis.
     # After each verification, user_id will be added end of this string
     # seperated by comma- ',' .
-    StringField('Verificators',)
+    StringField('Verificators',default='')
 ),
 )
 
@@ -245,12 +245,12 @@ class Analysis(BaseContent):
         if not verificators:
             self.setVerificators(username)
         else:
-            self.setVerificators(verificators.split(',').append(username).join(','))
+            self.setVerificators(verificators+","+username)
 
     def deleteLastVerificator(self):
         verificators=self.getVerificators().split(',')
         del verificators[-1]
-        self.setVerificators(verificators.join(','))
+        self.setVerificators(",".join(verificators))
 
     def wasVerifiedByUser(self,username):
         verificators=self.getVerificators().split(',')
@@ -1092,14 +1092,18 @@ class Analysis(BaseContent):
             return False
 
         #Checking verifiability depending on multi-verification type of bika_setup
-        if bika_setup.getNumberOfRequiredVerifications>1:
+        if self.bika_setup.getNumberOfRequiredVerifications>1:
             mv_type=self.bika_setup.getTypeOfmultiVerification()
             #If user verified before and self_multi_disabled, then return False
             if mv_type=='self_multi_disabled' and self.wasVerifiedByUser(username):
                 return False
-            # If user is the last verificator and multi-verification consecutively
+
+            # If user is the last verificator and consecutively multi-verification
             # is disabled, then return False
-            elif mv_type=='self_multi_not_cons' and username==self.getLastVerificator():
+            # Comparing was added just to check if this method is called before/after
+            # verification
+            elif mv_type=='self_multi_not_cons' and username==self.getLastVerificator() and \
+                self.getNumberOfVerifications()<self.getNumberOfRequiredVerifications():
                 return False
 
         # All checks pass

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -1087,6 +1087,22 @@ class Analysis(BaseContent):
         except WorkflowException:
             return ''
 
+    def getVerifiedBy(self):
+        """
+        Returns the identifier of the user who verified the result if the
+        state of the current analysis is "verified" or "published"
+        :return: the user_id of the user who did the last submission of result
+        """
+        workflow = getToolByName(self, "portal_workflow")
+        try:
+            review_history = workflow.getInfoFor(self, "review_history")
+            review_history = self.reverseList(review_history)
+            for event in review_history:
+                if event.get("action") == "verify":
+                    return event.get("actor")
+        except WorkflowException:
+            return ''
+
     def guard_sample_transition(self):
         workflow = getToolByName(self, "portal_workflow")
         if workflow.getInfoFor(self, "cancellation_state", "active") == "cancelled":

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -432,7 +432,8 @@ schema = BikaFolderSchema.copy() + Schema((
             label=_("Multi Verification type"),
             description = _(
                 "Choose type of multiple verification for the same user."
-                "This setting can enable/disable verifying/consecutively verifying more than once for the same user."),
+                "This setting can enable/disable verifying/consecutively verifying"
+                "more than once for the same user."),
             format='select',
         )
     ),

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -424,6 +424,18 @@ schema = BikaFolderSchema.copy() + Schema((
                 "any Analysis in Analysis Service edit view. By default, 1"),
         ),
     ),
+    StringField('TypeOfmultiVerification',
+        schemata = "Analyses",
+        default = 'self_multi_enabled',
+        vocabulary = MULTI_VERIFICATION_TYPE,
+        widget = SelectionWidget(
+            label=_("Multi Verification type"),
+            description = _(
+                "Choose type of multiple verification for the same user."
+                "This setting can enable/disable verifying/consecutively verifying more than once for the same user."),
+            format='select',
+        )
+    ),
     ReferenceField(
         'DryMatterService',
         schemata="Analyses",

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -51,6 +51,7 @@ from bika.lims.config import ATTACHMENT_OPTIONS
 from bika.lims.config import CURRENCIES
 from bika.lims.config import DECIMAL_MARKS
 from bika.lims.config import DEFAULT_AR_SPECS
+from bika.lims.config import MULTI_VERIFICATION_TYPE
 from bika.lims.config import PROJECTNAME
 from bika.lims.config import SCINOTATION_OPTIONS
 from bika.lims.config import WORKSHEET_LAYOUT_OPTIONS

--- a/bika/lims/tests/test_MultiVerificationTypes.py
+++ b/bika/lims/tests/test_MultiVerificationTypes.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Bika LIMS
+#
+# Copyright 2011-2016 by it's authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+
+
+from bika.lims.content.analysis import Analysis
+from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.tests.base import BikaFunctionalTestCase
+from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_NAME
+from Products.CMFCore.utils import getToolByName
+from bika.lims.utils import tmpID
+from Products.CMFPlone.utils import _createObjectByType
+from bika.lims.utils.analysisrequest import create_analysisrequest
+
+import unittest
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
+class Test_MultiVerificationType(BikaFunctionalTestCase):
+    """
+    In Bika Setup, When Multi verification is enabled, one of 3 types of Multi Verification
+    option should be chosen. Functional Testing of this new feature.
+    """
+    layer = BIKA_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(Test_MultiVerificationType, self).setUp()
+        login(self.portal, TEST_USER_NAME)
+
+    def tearDown(self):
+        logout()
+        super(Test_MultiVerificationType, self).tearDown()
+
+    def test_MultiVerificationType(self):
+
+        #Testing when the same user can verify multiple times
+        self.portal.bika_setup.setNumberOfRequiredVerifications(4)
+        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_enabled')
+
+        client = self.portal.clients['client-1']
+        sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+        values = {'Client': client.UID(),
+                  'Contact': client.getContacts()[0].UID(),
+                  'SamplingDate': '2016-12-12',
+                  'SampleType': sampletype.UID()}
+        ar = _createObjectByType("AnalysisRequest", client, tmpID())
+        servs = self.portal.bika_setup.bika_analysisservices
+        service=servs['analysisservice-3']
+        service.setSelfVerification(True)
+        an = _createObjectByType('Analysis', ar, tmpID())
+        member = self.portal.portal_membership.getMemberById('admin')
+        an.setService(service)
+        an.setVerificators(member.getUserName())
+        an.setNumberOfRequiredVerifications(4)
+        self.assertEquals(an.isUserAllowedToVerify(member), True)
+
+        #Testing when the same user can verify multiple times but not consequetively
+        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_not_cons')
+        self.assertEquals(an.isUserAllowedToVerify(member), False)
+
+        #Testing when the same user can not verify more than once
+        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_disabled')
+        self.assertEquals(an.isUserAllowedToVerify(member), False)
+
+        an.addVerificator(TEST_USER_NAME)
+        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_not_cons')
+        self.assertEquals(an.isUserAllowedToVerify(member), True)
+
+        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_disabled')
+        self.assertEquals(an.isUserAllowedToVerify(member), False)
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(Test_MultiVerificationType))
+    suite.layer = BIKA_FUNCTIONAL_TESTING
+    return suite

--- a/bika/lims/upgrade/to320.py
+++ b/bika/lims/upgrade/to320.py
@@ -42,6 +42,9 @@ def upgrade(tool):
     """
     wf = getToolByName(portal, 'portal_workflow')
     wf.updateRoleMappings()
+    # Updating Verifications of Analysis field from integer to String.
+    multi_verification(portal)
+
     return True
 
 
@@ -106,7 +109,21 @@ def create_samplingcoordinator(portal):
     bc = getToolByName(portal, 'bika_catalog', None)
     if 'getScheduledSamplingSampler' not in bc.indexes():
         bc.addIndex('getScheduledSamplingSampler', 'FieldIndex')
-def multi-verification(portal):
-    
-    #Coming soon
+def multi_verification(portal):
+    """
+    Getting all analyses with review_state in to_be_verified and
+    adding "admin" as a verificator as many times as this analysis verified before.
+    """
+    ac = getToolByName(portal, 'portal_catalog', None)
+    objs = pc(portal_type="Analyses",review_state="to_be_verified")
+    for obj_brain in objs:
+        obj = obj_brain.getObject()
+        old_field = obj.Schema().get("NumberOfVerifications", None)
+        if old_field:
+            new_value=''
+            for n in range(0,old_field):
+                new_value+='admin'
+                if n<old_field:
+                    new_value+=','
+            obj.setVerificators(new_value)
 

--- a/bika/lims/upgrade/to320.py
+++ b/bika/lims/upgrade/to320.py
@@ -106,3 +106,7 @@ def create_samplingcoordinator(portal):
     bc = getToolByName(portal, 'bika_catalog', None)
     if 'getScheduledSamplingSampler' not in bc.indexes():
         bc.addIndex('getScheduledSamplingSampler', 'FieldIndex')
+def multi-verification(portal):
+    
+    #Coming soon
+

--- a/bika/lims/upgrade/to320.py
+++ b/bika/lims/upgrade/to320.py
@@ -114,7 +114,7 @@ def multi_verification(portal):
     Getting all analyses with review_state in to_be_verified and
     adding "admin" as a verificator as many times as this analysis verified before.
     """
-    ac = getToolByName(portal, 'portal_catalog', None)
+    pc = getToolByName(portal, 'portal_catalog', None)
     objs = pc(portal_type="Analyses",review_state="to_be_verified")
     for obj_brain in objs:
         obj = obj_brain.getObject()

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -36,6 +36,7 @@ LIMS-2148: Unable to sort Bika Listing tables
 LIMS-1774: Shiny graphs for result ranges
 LIMS-2257: Scheduled sampling
 LIMS-2255: Switch to Chameleon (five.pt) for rendering TAL templates
+- Multi-verification of analyses, with different verification types
 - Add option to allow multi-approval (multi-verification) of results
 - Added Analyses section in the Dashboard
 - Add option to allow labman to self-verify analysis results


### PR DESCRIPTION
At the moment, the multi-verification allows the LabManager to set the number of verifications for an analysis are needed before an analysis being transitioned to the 'verified' status. Nevertheless, the same user (with "verifier" privileges) can trigger all the verifications until the analysis get verified.

The system must allow the LabManager to set one of the three options below in analysis service and also in Bika Setup when multi-verification is enabled:
- The analysis can be verified multiple-times by the same verifier
- The analysis can be verified multiple-times by the same verifier, but not consecutively
- The analysis cannot be verified multiple-times by the same user

A selection list in Bika Setup must be added below the option "Allow multi-verification of results", with the options listed above. This selection list will only be displayed if the value for the option "Allow multi-verification of results" is >= 2
A selection list in Analysis Service edit view must be added below the option "Allow multi-verification of results", with the options "System default" (by default, will take the value set in Bika Setup) plus the options listed above. This selection list will be displayed if the value for the option "Allow multi-verification of results" is >= 2. The value set here prevails over the value set in Bika Setup.



```
nihad@tesla:~/dev/bikalims/zinstance$ bin/test -v -p -s bika.lims --layer=bika.lims.testing.BikaTestingLayer:Functional
Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.190 seconds.
  Set up plone.app.testing.layers.PloneFixture in 7.257 seconds.
  Set up bika.lims.testing.BikaTestLayer in 1 minutes 3.164 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:
                                                                               
  Ran 45 tests with 0 failures and 0 errors in 5 minutes 25.580 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.015 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.064 seconds.
  Tear down plone.testing.z2.Startup in 0.005 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.004 seconds.
 ```