### PR TITLE
Change PDF filename on email to managers

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -850,7 +850,7 @@ class AnalysisRequestPublishView(BrowserView):
             if len(to) > 0:
                 # Send the email to the managers
                 mime_msg['To'] = ','.join(to)
-                attachPdf(mime_msg, pdf_report, pdf_fn)
+                attachPdf(mime_msg, pdf_report, ar.id)
 
                 try:
                     host = getToolByName(ar, 'MailHost')


### PR DESCRIPTION
The current publishing method sends a report to the client with the AR id as the name of the PDF file, but the file sent to the lab manager has the random tempfile id.