### PR TITLE
LIMS-2502: Stickers did not print when receiving from batch/analysisrequests

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -248,6 +248,7 @@ class WorkflowAction:
             # selected_items is a list of UIDs (stickers for AR_add use IDs)
             q += ",".join(transitioned)
             dest = self.context.absolute_url() + q
+            self.destination_url = dest
 
         return len(transitioned), dest
 


### PR DESCRIPTION
Regression introduced since last release, so I did not add this entry to changelog.