### PR TITLE
LIMS-2558: Fix JavaScript Uncaught TypeError: Cannot read property 'checkbox' of undefined causes endless Spinner

### DIFF
--- a/bika/lims/browser/js/bika.lims.rejection.js
+++ b/bika/lims/browser/js/bika.lims.rejection.js
@@ -23,9 +23,14 @@
                  "RejectionReasons"]
          };
          window.bika.lims.jsonapi_read(request_data, function (data) {
-             if (data.success &&
-                 data.total_objects > 0) {
-                 var reasons_state = data.objects[0]['RejectionReasons'][0]['checkbox'];
+             if (data.success && data.total_objects > 0) {
+                 var rejection_reasons = data.objects[0]['RejectionReasons'];
+                 // https://jira.bikalabs.com/browse/LIMS-2558
+                 if (rejection_reasons.length == 0) {
+                     console.debug("bika.lims.rejection.RejectionKickOff: No rejection reasons found in ", data);
+                     return;
+                 }
+                 var reasons_state = rejection_reasons[0]['checkbox'];
                  if (reasons_state == undefined || reasons_state != 'on'){
                      $('a#workflow-transition-reject').closest('li').hide();
                  }

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+LIMS-2558: JavaScript Uncaught TypeError: Cannot read property 'checkbox' of undefined causes endless Spinner
 LIMS-2477: Reference Analysis has no dependencies; remove guard that assumes it does
 LIMS-2465: Not possible to translate Bika Listing Table Workflow Action Buttons
 LIMS-1391: Add configurable identifier types (CAS# for AnalysisService)


### PR DESCRIPTION
On a virgin bika.lims installation, the samples view shows an infinite spinner if the rejection workflow was not activated in bika setup.

This PR checks the array of rejection reasons first before accessing it with an index.

See: https://jira.bikalabs.com/browse/LIMS-2558