### PR TITLE
LIMS-2500 - Columns to be added to Sample Point lists

### DIFF
--- a/bika/lims/browser/client/views/samplepoints.py
+++ b/bika/lims/browser/client/views/samplepoints.py
@@ -39,22 +39,30 @@ class ClientSamplePointsView(BikaListingView):
                       'replace_url': 'absolute_url'},
             'Description': {'title': _('Description'),
                             'index': 'description'},
+            'Sample Types': {'title': _('Sample Types'),},
+            'Composite': {'title': _('Composite'),},
+            'Sampling Frequency': {'title': _('Sampling Frequency'),},
+            'Attachments': {'title': _('Attachments'),
+                      'replace_url': 'absolute_url'},
         }
         self.review_states = [
             {'id': 'default',
              'title': _('Active'),
              'contentFilter': {'inactive_state': 'active'},
              'transitions': [{'id': 'deactivate'}, ],
-             'columns': ['title', 'Description']},
+             'columns': ['title', 'Description', 'Sample Types', 'Composite',
+                         'Sampling Frequency', 'Attachments']},
             {'id': 'inactive',
              'title': _('Dormant'),
              'contentFilter': {'inactive_state': 'inactive'},
              'transitions': [{'id': 'activate'}, ],
-             'columns': ['title', 'Description']},
+             'columns': ['title', 'Description', 'Sample Types', 'Composite',
+                         'Sampling Frequency', 'Attachments']},
             {'id': 'all',
              'title': _('All'),
              'contentFilter': {},
-             'columns': ['title', 'Description']},
+             'columns': ['title', 'Description', 'Sample Types', 'Composite',
+                         'Sampling Frequency', 'Attachments']},
         ]
 
     def __call__(self):
@@ -65,3 +73,30 @@ class ClientSamplePointsView(BikaListingView):
                 {'url': 'createObject?type_name=SamplePoint',
                  'icon': '++resource++bika.lims.images/add.png'}
         return super(ClientSamplePointsView, self).__call__()
+
+    def folderitems(self):
+        items = BikaListingView.folderitems(self)
+        for x in range(len(items)):
+            if not items[x].has_key('obj'): continue
+            obj = items[x]['obj']
+            items[x]['replace']['title'] = "<a href='%s'>%s</a>" % \
+                 (items[x]['url'], items[x]['title'])
+            items[x]['Description'] = obj.Description()
+            titles = [st.Title() for st in obj.getSampleTypes()]
+            items[x]['Sample Types'] = ",".join(titles)
+            if obj.aq_parent.portal_type == 'Client':
+                items[x]['Owner'] = obj.aq_parent.Title()
+            else:
+                items[x]['Owner'] = self.context.bika_setup.laboratory.Title()
+            items[x]['Composite'] = 'Y' if obj.Composite else 'N'
+            sample_freq = obj.SamplingFrequency.keys()
+            sample_freq.sort()
+            sample_freq_str = ''
+            for value in sample_freq:
+                sample_freq_str += '%s %s ' % (
+                                value.title(), obj.SamplingFrequency[value])
+            items[x]['Sampling Frequency'] = sample_freq_str
+            items[x]['replace']['Attachments'] = \
+                            "<a href='%s/at_download/Attachment'>%s</a>" % \
+                                 (items[x]['url'], obj.AttachmentFile.filename)
+        return items

--- a/bika/lims/browser/client/views/samplepoints.py
+++ b/bika/lims/browser/client/views/samplepoints.py
@@ -74,29 +74,25 @@ class ClientSamplePointsView(BikaListingView):
                  'icon': '++resource++bika.lims.images/add.png'}
         return super(ClientSamplePointsView, self).__call__()
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['replace']['title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['title'])
-            items[x]['Description'] = obj.Description()
-            titles = [st.Title() for st in obj.getSampleTypes()]
-            items[x]['Sample Types'] = ",".join(titles)
-            if obj.aq_parent.portal_type == 'Client':
-                items[x]['Owner'] = obj.aq_parent.Title()
-            else:
-                items[x]['Owner'] = self.context.bika_setup.laboratory.Title()
-            items[x]['Composite'] = 'Y' if obj.Composite else 'N'
-            sample_freq = obj.SamplingFrequency.keys()
-            sample_freq.sort()
-            sample_freq_str = ''
-            for value in sample_freq:
-                sample_freq_str += '%s %s ' % (
-                                value.title(), obj.SamplingFrequency[value])
-            items[x]['Sampling Frequency'] = sample_freq_str
-            items[x]['replace']['Attachments'] = \
-                            "<a href='%s/at_download/Attachment'>%s</a>" % \
-                                 (items[x]['url'], obj.AttachmentFile.filename)
-        return items
+    def folderitem(self, obj, item, index):
+        item['replace']['title'] = "<a href='%s'>%s</a>" % \
+             (item['url'], item['title'])
+        item['Description'] = obj.Description()
+        titles = [st.Title() for st in obj.getSampleTypes()]
+        item['Sample Types'] = ",".join(titles)
+        if obj.aq_parent.portal_type == 'Client':
+            item['Owner'] = obj.aq_parent.Title()
+        else:
+            item['Owner'] = self.context.bika_setup.laboratory.Title()
+        item['Composite'] = 'Y' if obj.Composite else 'N'
+        sample_freq = obj.SamplingFrequency.keys()
+        sample_freq.sort()
+        sample_freq_str = ''
+        for value in sample_freq:
+            sample_freq_str += '%s %s ' % (
+                            value.title(), obj.SamplingFrequency[value])
+        item['Sampling Frequency'] = sample_freq_str
+        item['replace']['Attachments'] = \
+                        "<a href='%s/at_download/Attachment'>%s</a>" % \
+                             (item['url'], obj.AttachmentFile.filename)
+        return item


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/LIMS-2500

## Current behavior before PR
There was Title and Description columns only

## Desired behavior after PR is merged
Added other columns Sample Types, Composite Y/N, Sampling frequency, Attachments (hyperlinked)
And using folderitem instead of folderitems

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.


[1] https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2] https://www.python.org/dev/peps/pep-0008
