### PR TITLE
LIMS-2361 ws creation collapse empty analysis categories

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -331,6 +331,7 @@ class BikaListingView(BrowserView):
     # and complted inline.  This is useful for list which will have many
     # thousands of entries in many categories, where loading the entire list
     # in HTML would be very slow.
+    # If you want to use service categories set this option ajax_categories_url
     ajax_categories = False
 
     # using the following attribute, some python class may add a CSS class

--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -398,6 +398,7 @@ class ReferenceSamplesView(BikaListingView):
         ]
 
     def folderitem(self, obj, item, index):
+        workflow = getToolByName(obj, 'portal_workflow')
         if item.get('review_state', 'current') == 'current':
             # Check expiry date
             exdate = obj.getExpiryDate()

--- a/bika/lims/browser/worksheet/configure.zcml
+++ b/bika/lims/browser/worksheet/configure.zcml
@@ -107,6 +107,16 @@
 
     <!-- Ajax signatures -->
 
+    <!-- For add_control and blanks using service categories -->
+    <browser:page
+      for="bika.lims.interfaces.IWorksheet"
+      name="service_view"
+      class="bika.lims.browser.worksheet.views.ServicesView"
+      permission="zope.Public"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+
     <browser:page
       for="bika.lims.interfaces.IWorksheet"
       name="getServices"

--- a/bika/lims/browser/worksheet/views/add_control.py
+++ b/bika/lims/browser/worksheet/views/add_control.py
@@ -57,6 +57,7 @@ class AddControlView(BrowserView):
             self.request.response.redirect(self.context.absolute_url() + "/manage_results")
         else:
             self.Services = ServicesView(self.context, self.request)
+            self.Services.expand_all_categories = False
             self.Services.view_url = self.Services.base_url + "/add_control"
             return self.template()
 

--- a/bika/lims/browser/worksheet/views/add_control.py
+++ b/bika/lims/browser/worksheet/views/add_control.py
@@ -57,7 +57,6 @@ class AddControlView(BrowserView):
             self.request.response.redirect(self.context.absolute_url() + "/manage_results")
         else:
             self.Services = ServicesView(self.context, self.request)
-            self.Services.expand_all_categories = False
             self.Services.view_url = self.Services.base_url + "/add_control"
             return self.template()
 

--- a/bika/lims/browser/worksheet/views/services.py
+++ b/bika/lims/browser/worksheet/views/services.py
@@ -29,7 +29,10 @@ class ServicesView(BikaListingView):
         self.pagesize = 999999
         self.show_workflow_action_buttons = False
         self.show_categories=context.bika_setup.getCategoriseAnalysisServices()
-        self.expand_all_categories=True
+        self.expand_all_categories = False
+        self.ajax_categories = True
+        self.ajax_categories_url = self.base_url + '/service_view'
+        self.category_index = 'getCategoryTitle'
 
         self.columns = {
             'Service': {'title': _('Service'),

--- a/bika/lims/browser/worksheet/views/services.py
+++ b/bika/lims/browser/worksheet/views/services.py
@@ -77,9 +77,15 @@ class ServicesView(BikaListingView):
                 ws_services.append(service_uid)
         self.categories = []
         catalog = getToolByName(self, self.catalog)
-        services = catalog(portal_type = "AnalysisService",
-                           inactive_state = "active",
-                           sort_on = 'sortable_title')
+        query = dict(portal_type = "AnalysisService",
+                     inactive_state = "active",
+                     sort_on = 'sortable_title')
+        # This folderitems does not respect the ajax_category index value,
+        # like folderitems from bika_listing.py does.  So we must add it
+        # manually here.
+        if self.category_index and self.request.get('cat'):
+            query[self.category_index] = self.request.get('cat')
+        services = catalog(query)
         items = []
         for service in services:
             service_obj = service.getObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Analysis Categories sans any analyses on the WS should stay collapsed. It otherwise makes for way to much scrolling.

https://jira.bikalabs.com/browse/LIMS-2361

## Current behavior before PR
All the categories/services where expanded

## Desired behavior after PR is merged
Expand the categories/services that have selected values and collapse those that don't have a value

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
