### PR TITLE
LIMS-2335 Formatting the AR create table

### DIFF
--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -96,7 +96,7 @@ class AnalysisServicesView(ASV):
         # Add columns for each AR
         for arnum in range(self.ar_count):
             column = {
-                'title': _('AR ${ar_number}', mapping={'ar_number': arnum}),
+                'title': _('AR ${ar_number}', mapping={'ar_number': arnum + 1}),
                 'sortable': False,
                 'type': 'boolean',
             }

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -204,16 +204,16 @@ class AnalysisServicesView(BikaListingView):
             'Calculation': {
                 'title': _('Calculation')
             },
-            'CommercialID': {
-                'title': _('Commercial ID'),
-                'attr': 'getCommercialID',
-                'toggle': True
-            },
-            'ProtocolID': {
-                'title': _('Protocol ID'),
-                'attr': 'getProtocolID',
-                'toggle': True
-            },
+            #'CommercialID': {
+            #    'title': _('Commercial ID'),
+            #    'attr': 'getCommercialID',
+            #    'toggle': True
+            #},
+            #'ProtocolID': {
+            #    'title': _('Protocol ID'),
+            #    'attr': 'getProtocolID',
+            #    'toggle': True
+            #},
             'SortKey': {
                 'title': _('Sort Key'),
                 'index': 'sortKey',
@@ -232,8 +232,8 @@ class AnalysisServicesView(BikaListingView):
                          'Keyword',
                          'Method',
                          'Department',
-                         'CommercialID',
-                         'ProtocolID',
+                         #'CommercialID',
+                         #'ProtocolID',
                          'Instrument',
                          'Unit',
                          'Price',
@@ -255,8 +255,8 @@ class AnalysisServicesView(BikaListingView):
                          'Keyword',
                          'Method',
                          'Department',
-                         'CommercialID',
-                         'ProtocolID',
+                         #'CommercialID',
+                         #'ProtocolID',
                          'Instrument',
                          'Unit',
                          'Price',
@@ -276,8 +276,8 @@ class AnalysisServicesView(BikaListingView):
                          'Category',
                          'Method',
                          'Department',
-                         'CommercialID',
-                         'ProtocolID',
+                         #'CommercialID',
+                         #'ProtocolID',
                          'Instrument',
                          'Unit',
                          'Price',
@@ -329,8 +329,8 @@ class AnalysisServicesView(BikaListingView):
             # searches the schema for fields that match columns, it is still
             # not harmful to be explicit:
             item['Keyword'] = obj.getKeyword()
-            item['CommercialID'] = obj.getCommercialID()
-            item['ProtocolID'] = obj.getProtocolID()
+            #item['CommercialID'] = obj.getCommercialID()
+            #item['ProtocolID'] = obj.getProtocolID()
             item['SortKey'] = obj.getSortKey()
 
         cat = obj.getCategoryTitle()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
AR Create. Column count should start at 1, not 0
Also removed CommercialID and ProtocolID on the AR form
https://jira.bikalabs.com/browse/LIMS-2335

## Current behavior before PR
    Column (title)count started at 0, not 1
    CommercialID and ProtocolID was on the table
## Desired behavior after PR is merged
    Column (title)count starts at 1, not 0
    Removed CommercialID and ProtocolID on the table

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
