### PR TITLE
Worksheet/add_analyses: When parameters are modified, automatically filter analyses

### DIFF
--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -41,6 +41,11 @@ function WorksheetAddAnalysesView() {
 
     that.load = function() {
 
+        // Search fields (in Add Analyses) trigger the search button on change
+        $('.auto-search-on-change').live("change", function(){
+            $('.ws-analyses-search-button').click();
+        })
+
         // search form - selecting a category fills up the service selector
         $('[name="list_getCategoryTitle"]').live("change", function(){
             val = $('[name="list_getCategoryTitle"]').val();

--- a/bika/lims/browser/worksheet/templates/add_analyses.pt
+++ b/bika/lims/browser/worksheet/templates/add_analyses.pt
@@ -75,7 +75,7 @@
 				i18n:translate="">Category</label>
 			<select id="CategorySelector"
 					tal:attributes="name string:${form_id}_getCategoryTitle"
-					class="listing-filter">
+					class="listing-filter auto-search-on-change">
 				<option value="any" i18n:translate="">Any</option>
 				<tal:options repeat="category view/getCategories">
 					<option
@@ -90,7 +90,7 @@
 				i18n:translate="">Service</label>
 			<select id="ServiceSelector"
 					tal:attributes="name string:${form_id}_Title"
-					class="listing-filter">
+					class="listing-filter auto-search-on-change">
 				<option value="any" i18n:translate="">Any</option>
 				<tal:options repeat="service view/getServices">
 					<option
@@ -105,7 +105,7 @@
 				i18n:translate="">Client</label>
 			<select id="ClientSelector"
 					tal:attributes="name string:${form_id}_getClientTitle"
-					class="listing-filter">
+					class="listing-filter auto-search-on-change">
 				<option value="any" i18n:translate="">Any</option>
 				<tal:options repeat="client view/getClients">
 					<option


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Automatically display filtered list of analyses when search fields are changed, while adding analyses to a worksheet.

## Current behavior before PR

Any search parameter requires clicking the "search" button before modifying the list

## Desired behavior after PR is merged

The search button remains visible for visual clarity, but should normally not require clicking when any element with class='auto-search-on-change' is modified.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
