### PR TITLE
Lims 2065 display lab batch

### DIFF
--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -140,6 +140,8 @@ class BatchFolderContentsView(BikaListingView):
             obj = items[x]['obj']
 
             bid = obj.getBatchID()
+            if bid == '':
+                bid = obj.id
             items[x]['BatchID'] = bid
             items[x]['replace']['BatchID'] = "<a href='%s/%s'>%s</a>" % (items[x]['url'], 'analysisrequests', bid)
 

--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -140,8 +140,6 @@ class BatchFolderContentsView(BikaListingView):
             obj = items[x]['obj']
 
             bid = obj.getBatchID()
-            if bid == '':
-                bid = obj.id
             items[x]['BatchID'] = bid
             items[x]['replace']['BatchID'] = "<a href='%s/%s'>%s</a>" % (items[x]['url'], 'analysisrequests', bid)
 

--- a/bika/lims/content/batch.py
+++ b/bika/lims/content/batch.py
@@ -287,10 +287,12 @@ class Batch(ATFolder):
                 value.append(val)
         return value
 
-    #security.declarePublic('getBatchID')
+    security.declarePublic('getBatchID')
 
-    #def getBatchID(self):
-    #    return self.getId()
+    def getBatchID(self):
+        if self.BatchID != '':
+            return self.BatchID
+        return self.getId()
 
     def BatchLabelVocabulary(self):
         """ return all batch labels """

--- a/bika/lims/content/batch.py
+++ b/bika/lims/content/batch.py
@@ -71,7 +71,7 @@ schema = BikaFolderSchema.copy() + Schema((
         required=False,
         validators=('uniquefieldvalidator',),
         widget=StringWidget(
-            visible=False,
+            visible=True,
             label=_("Batch ID"),
         )
     ),
@@ -287,10 +287,10 @@ class Batch(ATFolder):
                 value.append(val)
         return value
 
-    security.declarePublic('getBatchID')
+    #security.declarePublic('getBatchID')
 
-    def getBatchID(self):
-        return self.getId()
+    #def getBatchID(self):
+    #    return self.getId()
 
     def BatchLabelVocabulary(self):
         """ return all batch labels """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
To make BatchID field editable
https://jira.bikalabs.com/browse/LIMS-2065

## Current behavior before PR
     The field BatchID on a batch was not editable and only the generated BatchID was shown on the        batches listing 
## Desired behavior after PR is merged
     Make BatchID editable and show the value on the list else show the generated BatchID
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
