### PR TITLE
LIMS-2589: Commented out User activity report

### DIFF
--- a/bika/lims/browser/reports/templates/administration.pt
+++ b/bika/lims/browser/reports/templates/administration.pt
@@ -129,6 +129,7 @@
                 </li>
             </ul>
 
+            <!--
             <h2 i18n:translate="">Traceability</h2>
             <ul id="toc-reports">
                 <li>
@@ -160,6 +161,7 @@
                     </div>
                 </li>
             </ul>
+            -->
         </fieldset>
     </div>
 </metal:content-core>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
      Remove user activity report
https://jira.bikalabs.com/browse/LIMS-2589

## Current behavior before PR
     It was taking too long to run the activity report
## Desired behavior after PR is merged
     Taken out the user activity report link
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
