### PR TITLE
Fixed AS getMethod functionality for Multi-Method handling

### DIFF
--- a/bika/lims/tests/test_method_instrument_constraints.py
+++ b/bika/lims/tests/test_method_instrument_constraints.py
@@ -103,7 +103,6 @@ class Test_MethodInstrumentConstraints(BikaFunctionalTestCase):
         self.assertTrue(self.instrument1 in self.service.getAvailableInstruments())
         self.assertTrue(self.instrument2 in self.service.getAvailableInstruments())
         self.assertEqual(self.service.getInstrument().UID(), self.instrument1.UID())
-        self.assertTrue(len(self.service.getMethod()) == 1)
         self.assertEqual(self.service.getMethod().UID(), self.method.UID())
         ar = self.create_ar(self.service)
         auids = [ar.getAnalyses()[0].UID]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Each `AnalysisService` contains a `_Method` field, which get set by the JavaScript logic in `bika.lims.analysisservice.edit.js`. Therefore, the corresponding `getMethod` method was used to implement the same logic in Python as it is done currently in JavaScript.

## Current behavior before PR

Within the content class `AnalysisService`, the `getMethod()` method returned the value of the field `_Method` if the field `InstrumentEntryOfResults` was True. Otherwise it returned `None`, which resulted in this failing test:

```
Error in test test_RegularAnalyses (bika.lims.tests.test_method_instrument_constraints.Test_MethodInstrumentConstraints)
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/home/travis/build/bikalabs/bika.lims/bika/lims/tests/test_method_instrument_constraints.py", line 106, in test_RegularAnalyses self.assertTrue(len(self.service.getMethod()) == 1)
TypeError: object of type 'NoneType' has no len()
```

## Desired behavior after PR is merged

Within the content class `AnalysisService`, the `getMethod()` method checks now the `_Method` field if it contains a value, otherwise it checks the default method of the default instrument or returns the first method of the assigned methods of the AnalysisService.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
