### PR TITLE
LIMS-2321: Fix instrument display view with multiple instruments assigned

### DIFF
--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -125,7 +125,8 @@ schema = BikaFolderSchema.copy() + BikaSchema.copy() + Schema((
         ),
     ),
 
-    ReferenceField('Methods',
+    ReferenceField(
+        'Methods',
         vocabulary='_getAvailableMethods',
         allowed_types=('Method',),
         relationship='InstrumentMethods',
@@ -137,9 +138,10 @@ schema = BikaFolderSchema.copy() + BikaSchema.copy() + Schema((
         ),
     ),
 
-    BooleanField('DisposeUntilNextCalibrationTest',
-        default = False,
-        widget = BooleanWidget(
+    BooleanField(
+        'DisposeUntilNextCalibrationTest',
+        default=False,
+        widget=BooleanWidget(
             label=_("De-activate until next calibration test"),
             description=_("If checked, the instrument will be unavailable until the next valid "
                           "calibration was performed. This checkbox will automatically be unchecked."),
@@ -406,7 +408,6 @@ class Instrument(ATFolder):
 
     @deprecated(comment="bika.lims.content.instrument.getMethodUID is \
                 deprecated and will be removed in Bika LIMS 3.3")
-
     def getMethodUIDs(self):
         uids = []
         if self.getMethods():

--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -44,6 +44,7 @@ from bika.lims.browser.widgets import DateTimeWidget
 from bika.lims.browser.widgets import RecordsWidget
 
 # bika.lims imports
+from bika.lims import api
 from bika.lims.utils import t
 from bika.lims.utils import to_utf8
 from bika.lims.config import PROJECTNAME
@@ -801,6 +802,29 @@ class Instrument(ATFolder):
                    review_state='to_be_verified')
         ans = [p.getObject() for p in prox]
         return [a for a in ans if a.getRawInstrument() == self.UID()]
+
+    def displayValue(self, vocab, value, widget):
+        """Overwrite the Script (Python) `displayValue.py` located at
+           `Products.Archetypes.skins.archetypes` to handle the references
+           of our Picklist Widget (Methods) gracefully.
+           This method gets called by the `picklist.pt` template like this:
+
+           display python:context.displayValue(vocab, value, widget);"
+        """
+        # Taken from the Script (Python)
+        t = self.restrictedTraverse('@@at_utils').translate
+
+        # ensure we have strings, otherwise the `getValue` method of
+        # Products.Archetypes.utils will raise a TypeError
+        def to_string(v):
+            if isinstance(v, basestring):
+                return v
+            return api.get_title(v)
+
+        if isinstance(value, (list, tuple)):
+            value = map(to_string, value)
+
+        return t(vocab, value, widget)
 
 
 schemata.finalizeATCTSchema(schema, folderish=True, moveDiscussion=False)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is part of LIMS-2321 and fixes the display view issue when Instruments have multiple methods assigned. For more details, see:

https://jira.bikalabs.com/browse/LIMS-2321

## Current behavior before PR

Instrument View fails when multiple methods are assigned:

Traceback:
```
  Module bika.lims.content.instrument, line 1, in <module>
  Module Products.Archetypes.browser.utils, line 27, in translate
  Module Products.Archetypes.utils, line 568, in getValue
TypeError: DisplayList keys must be strings or ints, got <type 'Acquisition.ImplicitAcquisitionWrapper'>
```

This is because the used `PicklistWidget` is not capable to handle referenced objects in its view template.

## Desired behavior after PR is merged

The view template of Instruments show all assigned Methods as comma separated strings.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
