### PR TITLE
LIMS-2505 Positon was a type string changed to int for sorting

### DIFF
--- a/bika/lims/browser/worksheet/views/analysisrequests.py
+++ b/bika/lims/browser/worksheet/views/analysisrequests.py
@@ -69,7 +69,7 @@ class AnalysisRequestsView(BikaListingView):
                 'url': ar.absolute_url(),
                 'relative_url': ar.absolute_url(),
                 'view_url': ar.absolute_url(),
-                'Position': pos,
+                'Position': int(pos) if pos.isdigit() else pos,
                 'RequestID': ar.id,
                 'Client': ar.aq_parent.Title(),
                 'created': self.ulocalized_time(ar.created()),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/LIMS-2505

## Current behavior before PR
   Sorting was done alphabetically
## Desired behavior after PR is merged
    Sorted by numbers
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
