### PR TITLE
#1971: Landscape Layout for Reports

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -254,6 +254,11 @@ class AnalysisRequestPublishView(BrowserView):
         """
         return self.request.form.get('hvisible', '0').lower() in ['true', '1']
 
+    def isLandscape(self):
+        """ Returns if the layout is landscape
+        """
+        return self.request.form.get('landscape', '0').lower() in ['true', '1']
+
     def explode_data(self, data, padding=''):
         out = ''
         for k,v in data.items():

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
@@ -50,6 +50,7 @@
                     left: <input class='option-margin' id="margin-left" type="text"/>
                 </div>
                 <div class='options-line'>
+                    <input type="checkbox" name="landscape" id='landscape' value="0"><span i18n:translate="">Landscape</span><br/>
                     <input type="checkbox" name="qcvisible" id='qcvisible' value="0"><span i18n:translate="">Show QC Analyses</span><br/>
                     <input type="checkbox" name="hvisible" id='hvisible' value="0"><span i18n:translate="">Show Hidden Analyses</span>
                 </div>
@@ -74,7 +75,9 @@
             html, body { margin: 0; }
             html { background-color:#cdcdcd; }
             body.A4 #ar_publish_container { width: 210mm; }
+            body.A4.landscape #ar_publish_container { width: 297mm; }
             body.letter #ar_publish_container { width: 216mm; }
+            body.letter.landscape #ar_publish_container { width: 279mm; }
             #report {
                 background-color:#ffffff;
             }

--- a/bika/lims/browser/js/bika.lims.analysisrequest.publish.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.publish.js
@@ -11,10 +11,12 @@ function AnalysisRequestPublishView() {
     var default_margins = [20, 20, 30, 20];
     var papersize = {
         'A4': {
+                size: 'A4',
                 dimensions: [210, 297],
                 margins:    [20, 20, 30, 20] },
 
         'letter': {
+                size: 'letter',
                 dimensions: [216, 279],
                 margins:    [20, 20, 30, 20] },
     };
@@ -52,6 +54,19 @@ function AnalysisRequestPublishView() {
         });
 
         $('#sel_format').change(function(e) {
+            reloadReport();
+        });
+
+        $('#landscape').click(function(e) {
+            // get the checkbox value
+            var landscape = $('#landscape').is(':checked') ? 1 : 0;
+            $('body').toggleClass("landscape", landscape);
+
+            // reverse the dimensions of all layouts
+            for (var key in papersize) {
+                papersize[key]["dimensions"].reverse();
+            }
+
             reloadReport();
         });
 
@@ -187,6 +202,8 @@ function AnalysisRequestPublishView() {
         var template = $('#sel_format').val();
         var qcvisible = $('#qcvisible').is(':checked') ? '1' : '0';
         var hvisible = $('#hvisible').is(':checked') ? '1' : '0';
+        var landscape = $('#landscape').is(':checked') ? '1' : '0';
+
         if ($('#report:visible').length > 0) {
             $('#report').fadeTo('fast', 0.4);
         }
@@ -196,7 +213,8 @@ function AnalysisRequestPublishView() {
             async: true,
             data: { "template": template,
                     "qcvisible": qcvisible,
-                    "hvisible": hvisible}
+                    "hvisible": hvisible,
+                    "landscape": landscape}
         })
         .always(function(data) {
             var htmldata = data;
@@ -222,9 +240,13 @@ function AnalysisRequestPublishView() {
     function load_layout() {
         // Set page layout (DIN-A4, US-letter, etc.)
         var currentlayout = $('#sel_layout').val();
+
+        var orientation = $('#landscape').is(':checked') ? 'landscape' : 'portrait';
+
         // Dimensions. All expressed in mm
         var dim = {
             size:         papersize[currentlayout].size,
+            orientation:  orientation,
             outerWidth:   papersize[currentlayout].dimensions[0],
             outerHeight:  papersize[currentlayout].dimensions[1],
             marginTop:    papersize[currentlayout].margins[0],
@@ -241,9 +263,10 @@ function AnalysisRequestPublishView() {
         $('#margin-left').val(dim.marginLeft);
 
         var layout_style =
-            '@page { size:  ' + dim.size + ' !important;' +
+            '@page { size:  ' + dim.size + ' ' + orientation + ' !important;' +
             '        width:  ' + dim.width + 'mm !important;' +
-            '        margin: 0mm '+dim.marginRight+'mm 0mm '+dim.marginLeft+'mm !important;';
+            '        margin: 0mm '+dim.marginRight+'mm 0mm '+dim.marginLeft+'mm !important;' +
+            '}';
         $('#layout-style').html(layout_style);
         $('#ar_publish_container').css({'width':dim.width + 'mm', 'padding': '0mm '+dim.marginRight + 'mm 0mm '+dim.marginLeft +'mm '});
         $('#ar_publish_header').css('margin', '0mm -'+dim.marginRight + 'mm 0mm -' +dim.marginLeft+'mm');

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,7 @@
 3.2.1 (unreleased)
 ------------------
+
+#1971: Allow Reports in Landscape
 LIMS-2509: Correctly save empty values for CoordinateField and DurationField
 LIMS-2600: Some improvements and fixes for Statements
 LIMS-2567: Show all ARs on worksheet when adding Duplicate analysis


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

See https://github.com/bikalabs/bika.lims/issues/1971 for details.

## Current behavior before PR

Publication reports allow only portrait printing.

## Desired behavior after PR is merged

A new checkbox "landscape" allows to switch the dimensions for landscape printing.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
