### PR TITLE
Fix i18n for AR Add context action

### DIFF
--- a/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
@@ -38,7 +38,8 @@
 				href python:view.context_actions[add_item]['url'];
 				class python:'context_action_link %s' % (view.context_actions[add_item].get('class',''))"
                style="padding:5px 1px 3px 1px;"
-               tal:condition="python:len(view.context_actions) > 0">ARs
+               tal:condition="python:len(view.context_actions) > 0">
+              <span i18n:translate="">ARs</span>
             </a>
         </tal:add_actions>
     </h1>

--- a/bika/lims/browser/client/views/analysisrequests.py
+++ b/bika/lims/browser/client/views/analysisrequests.py
@@ -41,7 +41,7 @@ class ClientAnalysisRequestsView(AnalysisRequestsView):
                 addPortalMessage(msg)
             else:
                 if mtool.checkPermission(AddAnalysisRequest, self.context):
-                    self.context_actions[t(_('Add'))] = {
+                    self.context_actions[_('Add')] = {
                         'url': self.context.absolute_url() + \
                                "/portal_factory/AnalysisRequest" + \
                                "/Request new analyses/ar_add",

--- a/bika/lims/locales/af/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/af/LC_MESSAGES/bika.po
@@ -574,6 +574,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Ontledingsversoeke"
 
+msgid "ARs"
+msgstr "Ontledingsversoeke"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/el/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/el/LC_MESSAGES/bika.po
@@ -573,6 +573,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Αιτήσεις Ανάλυσης"
 
+msgid "ARs"
+msgstr "Αιτήσεις Ανάλυσης"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/es/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es/LC_MESSAGES/bika.po
@@ -585,6 +585,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Solicitudes de análisis"
 
+msgid "ARs"
+msgstr "Solicitudes de análisis"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr "Solicitud de análisis por preservar"

--- a/bika/lims/locales/es_PE/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_PE/LC_MESSAGES/bika.po
@@ -572,6 +572,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Solicitudes de análisis"
 
+msgid "ARs"
+msgstr "Solicitudes de análisis"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/fa/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fa/LC_MESSAGES/bika.po
@@ -574,6 +574,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "درخواستهای آزمون"
 
+msgid "ARs"
+msgstr "درخواستهای آزمون"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/fr/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fr/LC_MESSAGES/bika.po
@@ -588,6 +588,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Demandes d'analyse"
 
+msgid "ARs"
+msgstr "Demandes d'analyse"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/hu/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/hu/LC_MESSAGES/bika.po
@@ -572,6 +572,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Vizsgálat kérések"
 
+msgid "ARs"
+msgstr "Vizsgálat kérések"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/it/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/it/LC_MESSAGES/bika.po
@@ -580,6 +580,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Richieste di Analisi"
 
+msgid "ARs"
+msgstr "Richieste di Analisi"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/ro_RO/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ro_RO/LC_MESSAGES/bika.po
@@ -572,6 +572,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Cereri analize"
 
+msgid "ARs"
+msgstr "Cereri analize"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/tr_TR/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/tr_TR/LC_MESSAGES/bika.po
@@ -575,6 +575,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Analiz Talepleri"
 
+msgid "ARs"
+msgstr "Analiz Talepleri"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/uk_UA/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/uk_UA/LC_MESSAGES/bika.po
@@ -571,6 +571,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "Запити на аналіз"
 
+msgid "ARs"
+msgstr "Запити на аналіз"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/bika/lims/locales/zh_TW/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/zh_TW/LC_MESSAGES/bika.po
@@ -572,6 +572,9 @@ msgstr ""
 msgid "Analysis Requests"
 msgstr "分析請求"
 
+msgid "ARs"
+msgstr "分析請求"
+
 #: bika/lims/browser/dashboard.py:186
 msgid "Analysis Requests to be preserved"
 msgstr ""

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+Issue-1984: Analysisrequest "Add XX ARs" context action not translated
 LIMS-2509: Correctly save empty values for CoordinateField and DurationField
 LIMS-2600: Some improvements and fixes for Statements
 LIMS-2567: Show all ARs on worksheet when adding Duplicate analysis


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

See GitHub issue https://github.com/bikalabs/bika.lims/issues/1984 for details.

## Current behavior before PR

Context Action for AR Add view not translated

## Desired behavior after PR is merged

Translation works for the "Add" icon label and for the "ARs" label

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
