### PR TITLE
CSS improvements for AR Add View

### DIFF
--- a/bika/lims/browser/analysisrequest/templates/ar_add_by_col.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add_by_col.pt
@@ -6,24 +6,33 @@
     <link rel="stylesheet" type="text/css" media="all" href=""
             tal:attributes="href string:${portal/absolute_url}/bika_widgets/referencewidget.css"/>
     <style media="screen" type="text/css">
-        #singleservice {
-            width:90%;
-        }
-        .partnr {
-            color: #555;
-            font-size: 86%;
-        }
-        .nowrap{
-            white-space: nowrap;
-        }
-        .copybutton {
-            cursor: pointer;
-        }
+     #singleservice {
+         width:90%;
+     }
+     .partnr {
+         color: #555;
+         font-size: 86%;
+     }
+     .nowrap{
+         white-space: nowrap;
+     }
+     .copybutton {
+         cursor: pointer;
+     }
+     .analysisrequest tr:hover>* {
+         background-color: #e7e7e7!important;
+     }
+     .analysisrequest th {
+         width: 10%;
+         border: 1px solid #e7e7e7!important;
+     }
+     .analysisrequest tfoot tr td {
+         border-right: 1px solid #ddd!important;
+     }
     </style>
     <table summary="Add analysis requests"
            class="listing analysisrequest add nosort"
            cellpadding="0" cellspacing="0">
-        <thead>
         <thead class="analysisrequest_add_by_col">
             <!-- All edit fields with fields with add=visible -->
             <tal:field tal:repeat="field python:view.get_fields_with_visibility('edit')">

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+Issue-1975: Matching the labels to the fields is not easy when the user wants to add a single AR
 LIMS-2509: Correctly save empty values for CoordinateField and DurationField
 LIMS-2600: Some improvements and fixes for Statements
 LIMS-2567: Show all ARs on worksheet when adding Duplicate analysis


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

See https://github.com/bikalabs/bika.lims/issues/1975 for details

## Current behavior before PR

No row highlighting and nor borders for label column, which makes it hard to use on wide-screens.

## Desired behavior after PR is merged

Row highlighting and border lines make it easier for the user to add new ARs

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
