### PR TITLE
Added missing Aggregatedanalyses view registration

### DIFF
--- a/bika/lims/browser/configure.zcml
+++ b/bika/lims/browser/configure.zcml
@@ -54,6 +54,14 @@
 
   <browser:page
       for="*"
+      name="aggregatedanalyses"
+      class="bika.lims.browser.aggregatedanalyses.AggregatedAnalysesView"
+      permission="zope.Public"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+  <browser:page
+      for="*"
       name="log"
       class="bika.lims.browser.log.LogView"
       permission="zope2.View"

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+Issue-1967: Dashboard Link to "aggregatedanalyses" results in a 404
 Issue-1975: Matching the labels to the fields is not easy when the user wants to add a single AR
 LIMS-2509: Correctly save empty values for CoordinateField and DurationField
 LIMS-2600: Some improvements and fixes for Statements


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

See https://github.com/bikalabs/bika.lims/issues/1967 for details

## Current behavior before PR

Aggregatedanalyses link from dashboard resulted in a 404

## Desired behavior after PR is merged

Aggregatedanalyses View is displayed

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
