### PR TITLE
Bugfix/issue 1997 calculation formula description

### DIFF
--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -82,7 +82,6 @@ schema = BikaSchema.copy() + Schema((
         widget=TextAreaWidget(
             label=_("Calculation Formula"),
             description=_(
-                "calculation_formula_description",
                 "<p>The formula you type here will be dynamically calculated "
                 "when an analysis using this calculation is displayed.</p>"
                 "<p>To enter a Calculation, use standard maths operators,  "

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -1,38 +1,48 @@
+# -*- coding: utf-8 -*-
+
 # This file is part of Bika LIMS
 #
-# Copyright 2011-2016 by it's authors.
+# Copyright 2011-2017 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
+import re
+import sys
+import math
+
+import transaction
+from zope.interface import implements
 from AccessControl import ClassSecurityInfo
 
-from Products.ATExtensions.field import RecordsField
+from Products.Archetypes.atapi import Schema
+from Products.Archetypes.atapi import BaseFolder
+from Products.Archetypes.atapi import registerType
 from Products.CMFPlone.utils import safe_unicode
-from bika.lims import bikaMessageFactory as _
-from bika.lims.browser.widgets import RecordsWidget
-from bika.lims.utils import t
-from bika.lims.browser.fields import HistoryAwareReferenceField
-from bika.lims.browser.fields import InterimFieldsField
-from bika.lims.browser.widgets import RecordsWidget as BikaRecordsWidget
-from bika.lims.config import PROJECTNAME
-from bika.lims.content.bikaschema import BikaSchema
-from bika.lims.interfaces import ICalculation
-from bika.lims.utils import to_utf8
-from bika.lims.utils.analysis import format_numeric_result
-from Products.Archetypes.public import *
 from Products.Archetypes.references import HoldingReference
-from Products.ATContentTypes.lib.historyaware import HistoryAwareMixin
-from Products.CMFCore.permissions import ModifyPortalContent, View
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
-from zExceptions import Redirect
-from zope.interface import implements
-import sys
-import re
-import math
-import transaction
+from Products.ATContentTypes.lib.historyaware import HistoryAwareMixin
+
+# Fields
+from Products.Archetypes.atapi import TextField
+from Products.ATExtensions.field import RecordsField
+from bika.lims.browser.fields import InterimFieldsField
+from bika.lims.browser.fields import HistoryAwareReferenceField
+
+# Widgets
+from Products.Archetypes.atapi import ReferenceWidget
+from Products.Archetypes.atapi import TextAreaWidget
+from bika.lims.browser.widgets import RecordsWidget
+from bika.lims.browser.widgets import RecordsWidget as BikaRecordsWidget
+
+# bika.lims imports
+from bika.lims.config import PROJECTNAME
+from bika.lims import bikaMessageFactory as _
+from bika.lims.interfaces import ICalculation
+from bika.lims.content.bikaschema import BikaSchema
 
 
 schema = BikaSchema.copy() + Schema((
+
     InterimFieldsField(
         'InterimFields',
         widget=BikaRecordsWidget(
@@ -48,6 +58,7 @@ schema = BikaSchema.copy() + Schema((
                 "sheet."),
         )
     ),
+
     HistoryAwareReferenceField(
         'DependentServices',
         required=1,
@@ -62,6 +73,7 @@ schema = BikaSchema.copy() + Schema((
             label=_("Dependent Analyses"),
         ),
     ),
+
     TextField(
         'Formula',
         validators=('formulavalidator',),
@@ -83,14 +95,15 @@ schema = BikaSchema.copy() + Schema((
                 "two Analysis Services.</p>"),
         )
     ),
+
     RecordsField(
         'TestParameters',
         required=False,
         subfields=('keyword', 'value'),
         subfield_labels={'keyword': _('Keyword'), 'value': _('Value')},
         subfield_readonly={'keyword': True, 'value': False},
-        subfield_types={'keyword':'string','value':'float'},
-        default=[{'keyword': '', 'value': 0},],
+        subfield_types={'keyword': 'string', 'value': 'float'},
+        default=[{'keyword': '', 'value': 0}],
         widget=RecordsWidget(
             label=_("Test Parameters"),
             description=_("To test the calculation, enter values here for all "
@@ -100,6 +113,7 @@ schema = BikaSchema.copy() + Schema((
             allowDelete=False,
         ),
     ),
+
     TextField(
         'TestResult',
         default_content_type='text/plain',
@@ -110,7 +124,8 @@ schema = BikaSchema.copy() + Schema((
                           "with test values.  You will need to save the "
                           "calculation before this value will be calculated."),
         )
-    )
+    ),
+
 ))
 
 schema['title'].widget.visible = True
@@ -118,10 +133,13 @@ schema['description'].widget.visible = True
 
 
 class Calculation(BaseFolder, HistoryAwareMixin):
+    """Calculation for Analysis Results
+    """
+    implements(ICalculation)
+
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema
-    implements(ICalculation)
 
     _at_rename_after_creation = True
 
@@ -181,8 +199,8 @@ class Calculation(BaseFolder, HistoryAwareMixin):
 
             set flat=True to get a simple list of AnalysisService objects
         """
-        if deps == None:
-            deps = [] if flat == True else {}
+        if deps is None:
+            deps = [] if flat is True else {}
 
         for service in self.getDependentServices():
             calc = service.getCalculation()
@@ -232,7 +250,7 @@ class Calculation(BaseFolder, HistoryAwareMixin):
          TestResult field.
         """
         # Create mapping from TestParameters
-        mapping = {x['keyword']:x['value'] for x in self.getTestParameters()}
+        mapping = {x['keyword']: x['value'] for x in self.getTestParameters()}
         # Gather up and parse formula
         formula = self.getMinifiedFormula()
         formula = formula.replace('[', '{').replace(']', '}').replace('  ', '')
@@ -291,5 +309,6 @@ class Calculation(BaseFolder, HistoryAwareMixin):
             pu.addPortalMessage(msg, 'error')
             transaction.get().abort()
             raise WorkflowException
+
 
 registerType(Calculation, PROJECTNAME)

--- a/bika/lims/locales/af/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/af/LC_MESSAGES/bika.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Afrikaans (http://www.transifex.com/bikalabs/bika-lims/language/af/)\n"
 "MIME-Version: 1.0\n"
@@ -174,6 +174,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -991,13 +995,13 @@ msgstr "Bereken presisie van onsekerheid"
 msgid "Calculation"
 msgstr "Berekening"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Berekening Formule"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Berekening Interim Velde"
 
@@ -1050,11 +1054,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Gekanselleer"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "Kan berekening nie aktiveer nie want die volgende afhanklike dienste is onaktief: ${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "Kan berekening nie deaktiveer nie, want dit word deur die volgende dienste gebruik: ${calc_services}"
 
@@ -1746,7 +1750,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Definieer 'n unieke indentifikasie kode vir die metode."
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1790,7 +1794,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Afhanklike Ontledings"
 
@@ -5162,11 +5166,11 @@ msgstr "Temperatuur"
 msgid "Template"
 msgstr "Templaat"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5408,7 +5412,7 @@ msgstr "Die profiel se sleutelwoord word gebruik om dit uniek te identifiseer in
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Die akkreditasie verwysingsnommer aan die laboratorium"
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5614,7 +5618,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "Te Bevestig"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6070,7 +6074,7 @@ msgid "Validator"
 msgstr "Valideerder"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Waarde"
@@ -6237,19 +6241,6 @@ msgstr ""
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
 msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "berekeningsformule beskrywing"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/af/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/af/LC_MESSAGES/plone.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Afrikaans (http://www.transifex.com/bikalabs/bika-lims/language/af/)\n"

--- a/bika/lims/locales/ar/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ar/LC_MESSAGES/bika.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Arabic (http://www.transifex.com/bikalabs/bika-lims/language/ar/)\n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -989,13 +993,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1048,11 +1052,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1744,7 +1748,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1788,7 +1792,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5160,11 +5164,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5612,7 +5616,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6068,7 +6072,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "القيمة"
@@ -6234,18 +6238,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/ar/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ar/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Arabic (http://www.transifex.com/bikalabs/bika-lims/language/ar/)\n"

--- a/bika/lims/locales/bg_BG/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/bg_BG/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Bulgarian (Bulgaria) (http://www.transifex.com/bikalabs/bika-lims/language/bg_BG/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/bg_BG/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/bg_BG/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Bulgarian (Bulgaria) (http://www.transifex.com/bikalabs/bika-lims/language/bg_BG/)\n"

--- a/bika/lims/locales/bika.pot
+++ b/bika/lims/locales/bika.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -169,6 +169,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -986,13 +990,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1045,11 +1049,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1741,7 +1745,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1785,7 +1789,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5157,11 +5161,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5403,7 +5407,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5609,7 +5613,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6065,7 +6069,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6228,11 +6232,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/bn/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/bn/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Bengali (http://www.transifex.com/bikalabs/bika-lims/language/bn/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/bn/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/bn/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Bengali (http://www.transifex.com/bikalabs/bika-lims/language/bn/)\n"

--- a/bika/lims/locales/ca/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ca/LC_MESSAGES/bika.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Catalan (http://www.transifex.com/bikalabs/bika-lims/language/ca/)\n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -989,13 +993,13 @@ msgstr "Calcula la precisió en base als valors d'incertesa"
 msgid "Calculation"
 msgstr "Càlcul"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Fórmula de càlcul"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Camps de càlcul provisionals"
 
@@ -1048,11 +1052,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Cancel·lat"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "No s'ha pogut activar el càlcul perquè depèn de serveis d'anàlisi que no estan actius: ${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "No s'ha pogut desactivar el càlcul perquè hi ha serveis d'anàlisi actius que en depenen: ${calc_services}"
 
@@ -1744,7 +1748,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1788,7 +1792,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Anàlisis dependents"
 
@@ -5160,11 +5164,11 @@ msgstr "Temperatura"
 msgid "Template"
 msgstr "Plantilla"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr "La paraula clau del perfil s'utilitza per a identificar-lo unívocament 
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Codi de referència que l'entitat acreditadora ha concedit al laboratori."
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5612,7 +5616,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "Pendent de verificar"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6068,7 +6072,7 @@ msgid "Validator"
 msgstr "Validador"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Valor"
@@ -6235,19 +6239,6 @@ msgstr ""
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
 msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "<p>El càlcul de la fórmula que introdueixi aquí es calcularà quan es mostri un servei d'anàlisi que en depèn.</p><p>Podeu utilitzar els operadors matemàtics estàndar, + - * / () i totes les paraules clau disponibles entre corxets [], que poden correspondre tan a serveis d'anàlisi com als camps incògnita que hàgiu especificat més amunt.</p><p>Per exemple, l'expresió pel càlcul de duresa total de l'aigua en funció de la concentració de calci total (ppm) i ions magnesi (ppm) seria: [Ca] + [Mg], on Ca i Mg són les paraules clau dels serveis d'anàlisi corresponents.</p>"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/ca/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ca/LC_MESSAGES/plone.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Catalan (http://www.transifex.com/bikalabs/bika-lims/language/ca/)\n"

--- a/bika/lims/locales/cs/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/cs/LC_MESSAGES/bika.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Czech (http://www.transifex.com/bikalabs/bika-lims/language/cs/)\n"
 "MIME-Version: 1.0\n"
@@ -174,6 +174,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -991,13 +995,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Výpočet"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Výpočetní vztah"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Výpočetní pole"
 
@@ -1050,11 +1054,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Zrušen"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1746,7 +1750,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1790,7 +1794,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Závislé analýzy"
 
@@ -5162,11 +5166,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5408,7 +5412,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5614,7 +5618,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6070,7 +6074,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6236,18 +6240,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/cs/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/cs/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Czech (http://www.transifex.com/bikalabs/bika-lims/language/cs/)\n"

--- a/bika/lims/locales/da_DK/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/da_DK/LC_MESSAGES/bika.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Danish (Denmark) (http://www.transifex.com/bikalabs/bika-lims/language/da_DK/)\n"
 "MIME-Version: 1.0\n"
@@ -174,6 +174,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -991,13 +995,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Beregning"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Beregning formel"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Beregning foreløbige felter"
 
@@ -1050,11 +1054,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Annulleret"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1746,7 +1750,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1790,7 +1794,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Afhængige analyser"
 
@@ -5162,11 +5166,11 @@ msgstr "Temperatur"
 msgid "Template"
 msgstr "Template"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5408,7 +5412,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5614,7 +5618,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "To be verified"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6070,7 +6074,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Værdi"
@@ -6236,18 +6240,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/da_DK/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/da_DK/LC_MESSAGES/plone.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Danish (Denmark) (http://www.transifex.com/bikalabs/bika-lims/language/da_DK/)\n"

--- a/bika/lims/locales/de/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/de/LC_MESSAGES/bika.po
@@ -30,8 +30,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-23 13:26+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: German (http://www.transifex.com/bikalabs/bika-lims/language/de/)\n"
 "MIME-Version: 1.0\n"
@@ -197,6 +197,15 @@ msgstr "<p>${service} benötigt die folgenden ausgewählten Dienste: </p><br/><p
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr "<p>Die folgenden Dienste hängen von ${service} ab, und werden deselektiert wenn Sie fortfahren:</p><br/><p>${deps}</p><br/><p>Wollen Sie die Auswahl jetzt löschen?</p>"
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
+msgstr ""
+"<p>Die Formel die Sie hier eingeben wird dynamisch berechnet, sobald eine Analyse angezeigt wird, welche diese Formel verwendet.</p>\n"
+"\n"
+"<p>Verwenden Sie für neue Berechnungen die mathematischen Standardoperationen + - * / ( ), sowie die verfügbaren Schlüsselwörter aus anderen Analysenleistungen und den Interimfeldern als Variablen. Letztere müssen in eckigen Klammern [ ] eingefügt werden.</p>\n"
+"\n"
+"<p>Beispiel: Um den Härtegrad zu berechnen, wird die Gesamtzahl der Calcium (ppm) und Magnesium (ppm) Ionen als [Ca] + [Mg] eingegeben, wobei Ca und Mg die Schlüsselwörter dieser beiden Analysenleistungen sind.</p>"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
@@ -757,7 +766,7 @@ msgstr "Vorlage anwenden"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Apply wide"
-msgstr "Generell anwenden"
+msgstr "Global anwenden"
 
 #: bika/lims/content/instrumentcertification.py:167
 msgid "Approved by"
@@ -1013,13 +1022,13 @@ msgstr "Berechne Präzision aus Unsicherheiten"
 msgid "Calculation"
 msgstr "Berechnung"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Berechnungsformel"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Zwischenrechnungsfeld"
 
@@ -1072,11 +1081,11 @@ msgstr "Abbrechen"
 msgid "Cancelled"
 msgstr "Storniert"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "Berechnung kann nicht verwendet werden weil die folgende Service zuordnung fehlt: ${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "Berechnung kann nicht verwendet da sie von folgenden Service verwendet wird: ${calc_services}"
 
@@ -1768,7 +1777,7 @@ msgstr "Definieren Sie den Datumsbereich"
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Definieren Sie einen ID Code für die Methode. Die ID ist eindeutig zu wählen."
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr "Definieren sie Interimfelder, wie z.B. Gefäßmaß oder Verdünnungsfaktor, falls Ihre Berechnung das erfordern sollte. Das Titelfeld wird als Spaltenüberschrift und Feldbezeichner verwendet, wo das Interimfeld verwendet wird. Wenn die Option 'Global anwenden' aktiviert ist, wird das Feld in einer Auswahlliste oberhalb eines Arbeitsblatts angezeigt, welches es erlaubt einen bestimmten Wert auf alle übereinstimmenden Felder auf dem Arbeitsblatt anzuwenden."
 
@@ -1812,7 +1821,7 @@ msgid "Departments"
 msgstr "Abteilungen"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Abhängige Analysen"
 
@@ -5184,11 +5193,11 @@ msgstr "Temperatur"
 msgid "Template"
 msgstr "Vorlage"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr "Parameter testen"
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr "Ergebnis testen"
 
@@ -5430,7 +5439,7 @@ msgstr "Das Kennwort wird in Importdateien genutzt um es eindeutig dem entsprech
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Die Referenznummer, die dem Labor von der Akkreditierungsstelle zugewiesen wurde."
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "Das Ergebnis nach dieser Berechnung wurde aufgrund von Testwerten berechnet. Sie müssen die Berechnung speichern,  bevor dieser Wert berechnet werden kann."
 
@@ -5636,7 +5645,7 @@ msgstr "Zu beproben"
 msgid "To be verified"
 msgstr "Zu überprüfen"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr "Geben Sie hier die Werte für alle Berechnungsparameter ein, um diese Berechnung zu testen. Dies beinhaltet sowohl die Interimfelder, die zuvor definiert wurden, wie auch jede abhängige Analysenleistung, die für die Berechnung der Ergebnisse benötigt werden"
 
@@ -6092,7 +6101,7 @@ msgid "Validator"
 msgstr "Validiert von"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Wert"
@@ -6261,22 +6270,6 @@ msgstr "Bika LIMS Arbeitsprozesse passen zu allen Labor Disziplinen und sind kon
 #, fuzzy
 msgid "bika-frontpage-title"
 msgstr "<img src=\\\"${DYNAMIC_CONTENT}\\\" /> Willkomen auf Bika LIMS ${version} ${DYNAMIC_CONTENT}"
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr ""
-"<p>Die Formel die Sie hier eingeben wird dynamisch berechnet, sobald eine Analyse angezeigt wird, welche diese Formel verwendet.</p>\n"
-"<p>Verwenden Sie für neue Berechnungen die mathematischen Standardoperationen <pre>+ - * / ()</pre>, sowie die verfügbaren Schlüsselwörter aus anderen Analysenleistungen und den Interimfeldern als Variablen. Letztere müssen in eckigen Klammern <pre>[]</pre> eingefügt werden.</p>\n"
-"<p>Beispiel: Um den Härtegrad zu berechnen, wird die Gesamtzahl der Calcium und Magnesium Ionen (ppm) wie folgt eingegeben <pre>[Ca] + [Mg]</pre>, wobei <pre>Ca</pre> und <pre>Mg</pre> die Schlüsselwörter dieser beiden Analysenleistungen ist."
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/de/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/de/LC_MESSAGES/plone.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-23 16:17+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-24 08:15+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: German (http://www.transifex.com/bikalabs/bika-lims/language/de/)\n"
 "MIME-Version: 1.0\n"
@@ -409,7 +409,7 @@ msgstr "Labor"
 
 #: bika/lims/profiles/default/controlpanel.xml
 msgid "Laboratory Information"
-msgstr "Labor Information"
+msgstr "Laborinformation"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 #: bika/lims/profiles/default/types/Sample.xml
@@ -839,7 +839,7 @@ msgstr "Anzeigen"
 
 #: bika/lims/profiles/default/types/Client.xml
 msgid "WINE-40: Do not move or remove this entry."
-msgstr ""
+msgstr "WINE-40: Do not move or remove this entry."
 
 #: bika/lims/profiles/default/types/Worksheet.xml
 msgid "Worksheet"

--- a/bika/lims/locales/el/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/el/LC_MESSAGES/bika.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Greek (http://www.transifex.com/bikalabs/bika-lims/language/el/)\n"
 "MIME-Version: 1.0\n"
@@ -173,6 +173,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -990,13 +994,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Υπολογισμός"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1049,11 +1053,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Ακυρώθηκε"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1745,7 +1749,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1789,7 +1793,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5161,11 +5165,11 @@ msgstr "Θερμοκρασία"
 msgid "Template"
 msgstr "Πρότυπο"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5407,7 +5411,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5613,7 +5617,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6069,7 +6073,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Τιμή"
@@ -6236,19 +6240,6 @@ msgstr ""
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
 msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "calculation_formula_description"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/el/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/el/LC_MESSAGES/plone.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Greek (http://www.transifex.com/bikalabs/bika-lims/language/el/)\n"

--- a/bika/lims/locales/en/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/en/LC_MESSAGES/bika.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -166,6 +166,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -983,13 +987,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1042,11 +1046,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1738,7 +1742,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1782,7 +1786,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5154,11 +5158,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5400,7 +5404,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5606,7 +5610,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6062,7 +6066,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6225,11 +6229,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/en/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/en/LC_MESSAGES/plone.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/bika/lims/locales/en_ES/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/en_ES/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: English (Spain) (http://www.transifex.com/bikalabs/bika-lims/language/en_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/en_ES/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/en_ES/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: English (Spain) (http://www.transifex.com/bikalabs/bika-lims/language/en_ES/)\n"

--- a/bika/lims/locales/en_US/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/en_US/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: English (United States) (http://www.transifex.com/bikalabs/bika-lims/language/en_US/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/en_US/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/en_US/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: English (United States) (http://www.transifex.com/bikalabs/bika-lims/language/en_US/)\n"

--- a/bika/lims/locales/eo/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/eo/LC_MESSAGES/bika.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Esperanto (http://www.transifex.com/bikalabs/bika-lims/language/eo/)\n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -989,13 +993,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1048,11 +1052,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1744,7 +1748,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1788,7 +1792,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5160,11 +5164,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5612,7 +5616,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6068,7 +6072,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6234,18 +6238,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/eo/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/eo/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Esperanto (http://www.transifex.com/bikalabs/bika-lims/language/eo/)\n"

--- a/bika/lims/locales/es/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es/LC_MESSAGES/bika.po
@@ -19,8 +19,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/bikalabs/bika-lims/language/es/)\n"
 "MIME-Version: 1.0\n"
@@ -185,6 +185,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -1002,13 +1006,13 @@ msgstr "Calcular precisión de acuerdo a incertidumbre"
 msgid "Calculation"
 msgstr "Cálculo"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Fórmula de cálculo"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Campos de cálculo provisionales"
 
@@ -1061,11 +1065,11 @@ msgstr "Cancelar"
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "No ha sido posible activar el cálculo porque depende de servicios de análisis que no están activos: ${inactive_services} "
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "No ha sido posible desactivar el cálculo porque hay servicios de análisis activos que dependen de él: ${calc_services}"
 
@@ -1757,7 +1761,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1801,7 +1805,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Análisis dependientes"
 
@@ -5173,11 +5177,11 @@ msgstr "Temperatura"
 msgid "Template"
 msgstr "Plantilla"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5419,7 +5423,7 @@ msgstr "La palabra clave del perfil se utiliza para identificarlo inequívocamen
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Código de referencia que la entidad de acreditación ha concedido al laboratorio."
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5625,7 +5629,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "Pendiente de verificación"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6081,7 +6085,7 @@ msgid "Validator"
 msgstr "Validador"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Valor"
@@ -6248,19 +6252,6 @@ msgstr ""
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
 msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "<p>La fórmula introducida aquí se calculará dinámicamente cuando se muestre un análisis que la utilice.</p><p>Para introducir un cálculo, puede utilizar los operadores matemáticos estándar, + - * / (), y todas las palabras clave disponibles entre corchetes [], ya correspondan a servicios de análisis o a campos incógnita especificados arriba.</p><p>Por ejemplo, el cálculo de dureza total del agua en función de la concentración de calcio total (ppm) e iones de magnesio (ppm) se expresaría con la fórmula siguiente: [Ca] + [Mg], dónde Ca y Mg son las palabras clave de los servicios de análisis correspondientes.</p>"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/es/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es/LC_MESSAGES/plone.po
@@ -16,7 +16,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-30 20:33+0000\n"
 "Last-Translator: Leonardo Rojas <leonardorojass@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/bikalabs/bika-lims/language/es/)\n"

--- a/bika/lims/locales/es_419/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_419/LC_MESSAGES/bika.po
@@ -6,9 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-20 00:32+0000\n"
-"Last-Translator: Didinson Muñoz <dmunozcster@gmail.com>\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
+"Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Latin America) (http://www.transifex.com/bikalabs/bika-lims/language/es_419/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -173,6 +173,10 @@ msgstr "<p>${service} requiere que los siguientes servicios sean seleccionados:<
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr "<p>Los siguientes servicio dependen de ${service}, y no serán seleccionados si continúa:</p><br/><p>${deps}</p><br/><p>Desea quitar estas selecciones ahora?</p>"
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
+msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
@@ -989,13 +993,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1048,11 +1052,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1744,7 +1748,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1788,7 +1792,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5160,11 +5164,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5612,7 +5616,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6068,7 +6072,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6234,18 +6238,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/es_419/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es_419/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Latin America) (http://www.transifex.com/bikalabs/bika-lims/language/es_419/)\n"

--- a/bika/lims/locales/es_AR/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_AR/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/bikalabs/bika-lims/language/es_AR/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/es_AR/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es_AR/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/bikalabs/bika-lims/language/es_AR/)\n"

--- a/bika/lims/locales/es_MX/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_MX/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/bikalabs/bika-lims/language/es_MX/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/es_MX/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es_MX/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/bikalabs/bika-lims/language/es_MX/)\n"

--- a/bika/lims/locales/es_PE/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_PE/LC_MESSAGES/bika.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Peru) (http://www.transifex.com/bikalabs/bika-lims/language/es_PE/)\n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -989,13 +993,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Cálculo"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Fórmula de cálculo"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Campos de cálculo provisionales"
 
@@ -1048,11 +1052,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "No ha sido posible activar el cálculo porque depende de servicios de análisis que no están activos: ${inactive_services} "
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "No ha sido posible desactivar el cálculo porque hay servicios de análisis activos que dependen de él: ${calc_services}"
 
@@ -1744,7 +1748,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1788,7 +1792,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Análisis dependientes"
 
@@ -5160,11 +5164,11 @@ msgstr "Temperatura"
 msgid "Template"
 msgstr "Plantilla"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr "La palabra clave del perfil se utiliza para identificarlo inequívocamen
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Código de referencia que la entidad de acreditación ha concedido al laboratorio."
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5612,7 +5616,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "Pendiente de verificación"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6068,7 +6072,7 @@ msgid "Validator"
 msgstr "Validador"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Valor"
@@ -6235,19 +6239,6 @@ msgstr ""
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
 msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "<p>La fórmula introducida aquí se calculará dinámicamente cuando se muestre un análisis que la utilice.</p><p>Para introducir un cálculo, puede utilizar los operadores matemáticos estándar, + - * / (), y todas las palabras clave disponibles entre corchetes [], ya correspondan a servicios de análisis o a campos incógnita especificados arriba.</p><p>Por ejemplo, el cálculo de dureza total del agua en función de la concentración de calcio total (ppm) e iones de magnesio (ppm) se expresaría con la fórmula siguiente: [Ca] + [Mg], dónde Ca y Mg son las palabras clave de los servicios de análisis correspondientes.</p>"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/es_PE/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es_PE/LC_MESSAGES/plone.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Peru) (http://www.transifex.com/bikalabs/bika-lims/language/es_PE/)\n"

--- a/bika/lims/locales/fa/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fa/LC_MESSAGES/bika.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Persian (http://www.transifex.com/bikalabs/bika-lims/language/fa/)\n"
 "MIME-Version: 1.0\n"
@@ -174,6 +174,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -991,13 +995,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "محاسبه"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "فرمول محاسبه"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "فیلدهای حین محاسباتی"
 
@@ -1050,11 +1054,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "کنسل شده"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1746,7 +1750,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1790,7 +1794,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "آزمونهای وابسته"
 
@@ -5162,11 +5166,11 @@ msgstr "دما"
 msgid "Template"
 msgstr "الگو"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5408,7 +5412,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5614,7 +5618,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "باید تایید شود"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6070,7 +6074,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "ارزش"
@@ -6236,18 +6240,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/fa/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/fa/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Persian (http://www.transifex.com/bikalabs/bika-lims/language/fa/)\n"

--- a/bika/lims/locales/fa_IR/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fa_IR/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Persian (Iran) (http://www.transifex.com/bikalabs/bika-lims/language/fa_IR/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/fa_IR/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/fa_IR/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Persian (Iran) (http://www.transifex.com/bikalabs/bika-lims/language/fa_IR/)\n"

--- a/bika/lims/locales/fi/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fi/LC_MESSAGES/bika.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/bikalabs/bika-lims/language/fi/)\n"
 "MIME-Version: 1.0\n"
@@ -173,6 +173,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -990,13 +994,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Laskenta"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Laskentakaava"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1049,11 +1053,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Peruutettu"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1745,7 +1749,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1789,7 +1793,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5161,11 +5165,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5407,7 +5411,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5613,7 +5617,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6069,7 +6073,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6235,18 +6239,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/fi/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/fi/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/bikalabs/bika-lims/language/fi/)\n"

--- a/bika/lims/locales/fr/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fr/LC_MESSAGES/bika.po
@@ -22,8 +22,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: French (http://www.transifex.com/bikalabs/bika-lims/language/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -188,6 +188,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -1005,13 +1009,13 @@ msgstr "Calcule la précision à partir des incertitudes"
 msgid "Calculation"
 msgstr "Calcul"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Formule de calcul"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Champ(s) de calcul intermédiaire"
 
@@ -1064,11 +1068,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Annulé"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "Ne peut activer le calcul car les services suivants sont inactifs : ${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "Ne peut désactiver le calcul car utilisé par les services suivants : ${calc_services}"
 
@@ -1760,7 +1764,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Définissez un code d'identification pour la méthode. Il doit être unique"
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1804,7 +1808,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Analyses dépendantes"
 
@@ -5176,11 +5180,11 @@ msgstr "Température"
 msgid "Template"
 msgstr "Modèle"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5422,7 +5426,7 @@ msgstr "Le mot-clé du profil est utilisé pour l'identifier de manière unique 
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Code de référence délivré au laboratoire par l'organisme d'accréditation"
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5628,7 +5632,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "A vérifier"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6084,7 +6088,7 @@ msgid "Validator"
 msgstr "Apporbateur "
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Valeur"
@@ -6250,18 +6254,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/fr/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/fr/LC_MESSAGES/plone.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: French (http://www.transifex.com/bikalabs/bika-lims/language/fr/)\n"

--- a/bika/lims/locales/hi/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/hi/LC_MESSAGES/bika.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Hindi (http://www.transifex.com/bikalabs/bika-lims/language/hi/)\n"
 "MIME-Version: 1.0\n"
@@ -171,6 +171,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -988,13 +992,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1047,11 +1051,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1743,7 +1747,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1787,7 +1791,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5159,11 +5163,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5405,7 +5409,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5611,7 +5615,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6067,7 +6071,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6233,18 +6237,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/hi/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/hi/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Hindi (http://www.transifex.com/bikalabs/bika-lims/language/hi/)\n"

--- a/bika/lims/locales/hu/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/hu/LC_MESSAGES/bika.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/bikalabs/bika-lims/language/hu/)\n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -989,13 +993,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Számítás"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Számítási képlet"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Számítás ideiglenes mezők"
 
@@ -1048,11 +1052,11 @@ msgstr "Mégse"
 msgid "Cancelled"
 msgstr "Visszavont"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1744,7 +1748,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1788,7 +1792,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Függő vizsgálatok"
 
@@ -5160,11 +5164,11 @@ msgstr ""
 msgid "Template"
 msgstr "Sablon"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Az akkreditáló testület által a labornak kiadott hivatkozási szám."
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5612,7 +5616,7 @@ msgstr "Mintavételezendő"
 msgid "To be verified"
 msgstr "Ellenőrzendő"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6068,7 +6072,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6234,18 +6238,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/hu/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/hu/LC_MESSAGES/plone.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/bikalabs/bika-lims/language/hu/)\n"

--- a/bika/lims/locales/hu_HU/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/hu_HU/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Hungarian (Hungary) (http://www.transifex.com/bikalabs/bika-lims/language/hu_HU/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/hu_HU/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/hu_HU/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Hungarian (Hungary) (http://www.transifex.com/bikalabs/bika-lims/language/hu_HU/)\n"

--- a/bika/lims/locales/id/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/id/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Indonesian (http://www.transifex.com/bikalabs/bika-lims/language/id/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/id/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/id/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Indonesian (http://www.transifex.com/bikalabs/bika-lims/language/id/)\n"

--- a/bika/lims/locales/it/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/it/LC_MESSAGES/bika.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Italian (http://www.transifex.com/bikalabs/bika-lims/language/it/)\n"
 "MIME-Version: 1.0\n"
@@ -180,6 +180,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -997,13 +1001,13 @@ msgstr "Calcola Precisione da Incertezze"
 msgid "Calculation"
 msgstr "Calcoli"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Formula di Calcolo"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Campi Calcolo Provvisorio"
 
@@ -1056,11 +1060,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Cancellato"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "Impossibile attivare il calcolo, perché le seguenti dipendenze dei servizi non sono inattive: ${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "Impossibile disattivare il calcolo, perché è in uso da parte dei seguenti servizi: ${calc_services}"
 
@@ -1752,7 +1756,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Definisci un codice di identificazione per il metodo. Deve essere unico."
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1796,7 +1800,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Analisi Dipendente"
 
@@ -5168,11 +5172,11 @@ msgstr "Temperatura"
 msgid "Template"
 msgstr "Modello"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5414,7 +5418,7 @@ msgstr "La chiave di profilo è usata per identificarlo univocamente nei file di
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Il codice di riferimento rilasciato al laboratorio dall'ente di accreditamento"
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5620,7 +5624,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "Da verificare"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6076,7 +6080,7 @@ msgid "Validator"
 msgstr "Convalidatore"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Valore"
@@ -6245,19 +6249,6 @@ msgstr "bika-frontpage-description"
 #, fuzzy
 msgid "bika-frontpage-title"
 msgstr "bika-frontpage-title"
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "calculation_formula_description"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/it/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/it/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Italian (http://www.transifex.com/bikalabs/bika-lims/language/it/)\n"

--- a/bika/lims/locales/ja/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ja/LC_MESSAGES/bika.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Japanese (http://www.transifex.com/bikalabs/bika-lims/language/ja/)\n"
 "MIME-Version: 1.0\n"
@@ -173,6 +173,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -990,13 +994,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1049,11 +1053,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1745,7 +1749,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1789,7 +1793,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5161,11 +5165,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5407,7 +5411,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5613,7 +5617,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6069,7 +6073,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6235,18 +6239,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/ja/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ja/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Japanese (http://www.transifex.com/bikalabs/bika-lims/language/ja/)\n"

--- a/bika/lims/locales/ka_GE/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ka_GE/LC_MESSAGES/bika.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Georgian (Georgia) (http://www.transifex.com/bikalabs/bika-lims/language/ka_GE/)\n"
 "MIME-Version: 1.0\n"
@@ -171,6 +171,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -988,13 +992,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1047,11 +1051,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1743,7 +1747,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1787,7 +1791,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5159,11 +5163,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5405,7 +5409,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5611,7 +5615,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6067,7 +6071,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6233,18 +6237,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/ka_GE/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ka_GE/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Georgian (Georgia) (http://www.transifex.com/bikalabs/bika-lims/language/ka_GE/)\n"

--- a/bika/lims/locales/kn/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/kn/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Kannada (http://www.transifex.com/bikalabs/bika-lims/language/kn/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/kn/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/kn/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Kannada (http://www.transifex.com/bikalabs/bika-lims/language/kn/)\n"

--- a/bika/lims/locales/lt/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/lt/LC_MESSAGES/bika.po
@@ -10,8 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/bikalabs/bika-lims/language/lt/)\n"
 "MIME-Version: 1.0\n"
@@ -176,6 +176,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -993,13 +997,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Skaičiavimas"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Skaičiavimų išraiška"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Skaičiavimo tarpinė sritis"
 
@@ -1052,11 +1056,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Anuliuoti"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1748,7 +1752,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1792,7 +1796,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5164,11 +5168,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5410,7 +5414,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5616,7 +5620,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6072,7 +6076,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6238,18 +6242,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/lt/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/lt/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/bikalabs/bika-lims/language/lt/)\n"

--- a/bika/lims/locales/mn/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/mn/LC_MESSAGES/bika.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Mongolian (http://www.transifex.com/bikalabs/bika-lims/language/mn/)\n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -989,13 +993,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1048,11 +1052,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1744,7 +1748,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1788,7 +1792,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5160,11 +5164,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5612,7 +5616,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6068,7 +6072,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6234,18 +6238,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/mn/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/mn/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Mongolian (http://www.transifex.com/bikalabs/bika-lims/language/mn/)\n"

--- a/bika/lims/locales/nl/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/nl/LC_MESSAGES/bika.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/bikalabs/bika-lims/language/nl/)\n"
 "MIME-Version: 1.0\n"
@@ -171,6 +171,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -988,13 +992,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Berekeningsformule"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Berekeningvelden Interim"
 
@@ -1047,11 +1051,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Geannuleerd"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1743,7 +1747,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1787,7 +1791,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5159,11 +5163,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5405,7 +5409,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5611,7 +5615,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6067,7 +6071,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6233,18 +6237,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/nl/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/nl/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/bikalabs/bika-lims/language/nl/)\n"

--- a/bika/lims/locales/pl/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/pl/LC_MESSAGES/bika.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Polish (http://www.transifex.com/bikalabs/bika-lims/language/pl/)\n"
 "MIME-Version: 1.0\n"
@@ -177,6 +177,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -994,13 +998,13 @@ msgstr "Obliczenie Precyzji z Niepewności"
 msgid "Calculation"
 msgstr "Obliczanie"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Formuła obliczania"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Tymczasowe pola obliczeniowe"
 
@@ -1053,11 +1057,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Anulowane"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "Nie można włączyć obliczeń, ponieważ nie są aktywne następujące usługi podległe ${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "Nie można wyłączyć obliczeń, ponieważ są używne przez następujące usługi: ${calc_services}"
 
@@ -1749,7 +1753,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Zdefiniuj kod identyfikacyjny dla metody, który musi być unikalny."
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1793,7 +1797,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Analizy zależne"
 
@@ -5165,11 +5169,11 @@ msgstr "Temperatura"
 msgid "Template"
 msgstr "Szablon"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5411,7 +5415,7 @@ msgstr "Słowo kluczowe profilu, jest niezbędne dla jego dentyfikacji w importo
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Numer akredytacji przypisany laboratorium przez organ akredytacyjny"
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5617,7 +5621,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "Do sprawdzenia"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6073,7 +6077,7 @@ msgid "Validator"
 msgstr "Sprawdzający"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Wartość"
@@ -6242,19 +6246,6 @@ msgstr "opis_strony_tytułowej"
 #, fuzzy
 msgid "bika-frontpage-title"
 msgstr "tytuł_strony_tytułowej"
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "opis_formuły_obliczenniowej"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/pl/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/pl/LC_MESSAGES/plone.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Polish (http://www.transifex.com/bikalabs/bika-lims/language/pl/)\n"

--- a/bika/lims/locales/plone.pot
+++ b/bika/lims/locales/plone.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/bika/lims/locales/pt/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/pt/LC_MESSAGES/bika.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/bikalabs/bika-lims/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -177,6 +177,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -994,13 +998,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Calculo"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Fórmula de Cálculo"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1053,11 +1057,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1749,7 +1753,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1793,7 +1797,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5165,11 +5169,11 @@ msgstr "Temperatura"
 msgid "Template"
 msgstr "Tema"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5411,7 +5415,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5617,7 +5621,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "A verificar"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6073,7 +6077,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Valor"
@@ -6239,18 +6243,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/pt/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/pt/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/bikalabs/bika-lims/language/pt/)\n"

--- a/bika/lims/locales/pt_BR/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/pt_BR/LC_MESSAGES/bika.po
@@ -24,9 +24,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-22 17:28+0000\n"
-"Last-Translator: cruzrenato1 <renatorlcruz@gmail.com>\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
+"Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/bikalabs/bika-lims/language/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,6 +191,10 @@ msgstr "<p>${service} requer que os seguintes serviços sejam selecionados:</p><
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr "<p>Os seguintes serviços dependem de ${service} e não serão selecionados se você continuar:</p><br/><p>${deps}</p><br/><p> Para remover essas seleções agora?</P>"
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
+msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
@@ -1007,13 +1011,13 @@ msgstr "Calculo de precisão da incerteza"
 msgid "Calculation"
 msgstr "Cálculo"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Fórmula de Cálculo"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Campos de Cálculo Intermediário"
 
@@ -1066,11 +1070,11 @@ msgstr "Cancelar"
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "Impossível ativar o cálculo pois as seguintes dependências de serviços estão inativas: ${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "Impossível desativar o cálculo pois ele está em uso pelos seguintes serviços: ${calc_services}"
 
@@ -1762,7 +1766,7 @@ msgstr "Definir um intervalo de datas"
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Definir um código identificador para o método. Ele deve ser exclusivo."
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr "Defina campos interinos como massa do vasso, fatores de diluição, caso seu cálculo os exija. O título de campo especificado aqui será usado como cabeçalhos de colunas e descritores de campo onde os campos intermediários são exibidos. Se \"Aplicar ampla\" estiver ativado, o campo será exibido em uma caixa de seleção na parte superior da planilha, permitindo aplicar um valor específico a todos os campos correspondentes na planilha."
 
@@ -1806,7 +1810,7 @@ msgid "Departments"
 msgstr "Departamentos"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Análise Dependente"
 
@@ -5178,11 +5182,11 @@ msgstr "Temperatura"
 msgid "Template"
 msgstr "Modelo"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr "Parâmetros de teste"
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr "Resultado do teste"
 
@@ -5424,7 +5428,7 @@ msgstr "A palavra-chave do perfil é usada unicamente para identificá-lo em arq
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "O código de referência emitido pelo órgão de certificação."
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "O resultado após o cálculo foi realizado com valores de teste. Você precisará salvar o cálculo antes que esse valor seja calculado."
 
@@ -5630,7 +5634,7 @@ msgstr "Para ser amostrado"
 msgid "To be verified"
 msgstr "A verificar"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr "Para testar o cálculo, insira aqui valores para todos os parâmetros de cálculo. Isso inclui os campos intermediários definidos acima, bem como quaisquer serviços que este cálculo depende para calcular os resultados."
 
@@ -6086,7 +6090,7 @@ msgid "Validator"
 msgstr "Validador"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Valor"
@@ -6255,19 +6259,6 @@ msgstr "bika-descrição-paginainicial"
 #, fuzzy
 msgid "bika-frontpage-title"
 msgstr "bika-titulo-paginainicial"
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "descrição_da_fórmula_de_cálculo"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/pt_BR/LC_MESSAGES/plone.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-03-22 18:44+0000\n"
 "Last-Translator: cruzrenato1 <renatorlcruz@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/bikalabs/bika-lims/language/pt_BR/)\n"

--- a/bika/lims/locales/ro_RO/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ro_RO/LC_MESSAGES/bika.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Romanian (Romania) (http://www.transifex.com/bikalabs/bika-lims/language/ro_RO/)\n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -989,13 +993,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Calcul"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Formulă calcul"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1048,11 +1052,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "Anulat"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1744,7 +1748,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1788,7 +1792,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Analize dependente"
 
@@ -5160,11 +5164,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5612,7 +5616,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6068,7 +6072,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6234,18 +6238,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/ro_RO/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ro_RO/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Romanian (Romania) (http://www.transifex.com/bikalabs/bika-lims/language/ro_RO/)\n"

--- a/bika/lims/locales/ru/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ru/LC_MESSAGES/bika.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Russian (http://www.transifex.com/bikalabs/bika-lims/language/ru/)\n"
 "MIME-Version: 1.0\n"
@@ -178,6 +178,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -995,13 +999,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "Калькуляция"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Формула вычисления"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Расчет временных полей"
 
@@ -1054,11 +1058,11 @@ msgstr "Отменить"
 msgid "Cancelled"
 msgstr "Отменено"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "Не удается активировать расчет, так как следующие зависимости услуг являются неактивными: ${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "Не удается отключить вычисление, так как он используется следующими услугами: ${calc_services}"
 
@@ -1750,7 +1754,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1794,7 +1798,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Анализы подразделения"
 
@@ -5166,11 +5170,11 @@ msgstr "Температура"
 msgid "Template"
 msgstr "Шаблон"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5412,7 +5416,7 @@ msgstr "Профиль ключевое слово используется дл
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Код ссылки, выданного органом аккредитации лаборатории"
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5618,7 +5622,7 @@ msgstr "Ожидаемые образцы"
 msgid "To be verified"
 msgstr "На проверку"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6074,7 +6078,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Значение"
@@ -6240,18 +6244,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/ru/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ru/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-02-21 11:24+0000\n"
 "Last-Translator: Михаил Стручалин <m.struchalin@gmail.com>\n"
 "Language-Team: Russian (http://www.transifex.com/bikalabs/bika-lims/language/ru/)\n"

--- a/bika/lims/locales/sv/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/sv/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/bikalabs/bika-lims/language/sv/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/sv/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/sv/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/bikalabs/bika-lims/language/sv/)\n"

--- a/bika/lims/locales/ta/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ta/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Tamil (http://www.transifex.com/bikalabs/bika-lims/language/ta/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/ta/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ta/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Tamil (http://www.transifex.com/bikalabs/bika-lims/language/ta/)\n"

--- a/bika/lims/locales/te_IN/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/te_IN/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Telugu (India) (http://www.transifex.com/bikalabs/bika-lims/language/te_IN/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/te_IN/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/te_IN/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Telugu (India) (http://www.transifex.com/bikalabs/bika-lims/language/te_IN/)\n"

--- a/bika/lims/locales/tr_TR/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/tr_TR/LC_MESSAGES/bika.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/bikalabs/bika-lims/language/tr_TR/)\n"
 "MIME-Version: 1.0\n"
@@ -175,6 +175,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -992,13 +996,13 @@ msgstr "Belirsizliklerden Kesinlik Derecesini Hesapla"
 msgid "Calculation"
 msgstr "Hesaplama"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "Hesaplama Formülü"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Hesaplama Ara Alanları"
 
@@ -1051,11 +1055,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "İptal edildi"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "${inactive_services} etkin olmadığından hesaplama etkinleştirilemedi."
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "${calc_services} tarafından kullanımda olduğundan hesaplama devre dışı bırakılamadı."
 
@@ -1747,7 +1751,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1791,7 +1795,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "Bağımlı Analizler"
 
@@ -5163,11 +5167,11 @@ msgstr "Sıcaklık"
 msgid "Template"
 msgstr "Şablon"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5409,7 +5413,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5615,7 +5619,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "Doğrulanacak"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6071,7 +6075,7 @@ msgid "Validator"
 msgstr "Onaylayan"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Değer"
@@ -6237,18 +6241,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/tr_TR/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/tr_TR/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/bikalabs/bika-lims/language/tr_TR/)\n"

--- a/bika/lims/locales/uk_UA/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/uk_UA/LC_MESSAGES/bika.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Ukrainian (Ukraine) (http://www.transifex.com/bikalabs/bika-lims/language/uk_UA/)\n"
 "MIME-Version: 1.0\n"
@@ -171,6 +171,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -988,13 +992,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1047,11 +1051,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1743,7 +1747,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1787,7 +1791,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5159,11 +5163,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5405,7 +5409,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5611,7 +5615,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "На перевірку"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6067,7 +6071,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "Значення"
@@ -6233,18 +6237,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/uk_UA/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/uk_UA/LC_MESSAGES/plone.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Ukrainian (Ukraine) (http://www.transifex.com/bikalabs/bika-lims/language/uk_UA/)\n"

--- a/bika/lims/locales/ur/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ur/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Urdu (http://www.transifex.com/bikalabs/bika-lims/language/ur/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/ur/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ur/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Urdu (http://www.transifex.com/bikalabs/bika-lims/language/ur/)\n"

--- a/bika/lims/locales/vi/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/vi/LC_MESSAGES/bika.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/bikalabs/bika-lims/language/vi/)\n"
 "MIME-Version: 1.0\n"
@@ -170,6 +170,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -987,13 +991,13 @@ msgstr ""
 msgid "Calculation"
 msgstr ""
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr ""
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
 
@@ -1046,11 +1050,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1742,7 +1746,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr ""
 
@@ -5158,11 +5162,11 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5404,7 +5408,7 @@ msgstr ""
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5610,7 +5614,7 @@ msgstr ""
 msgid "To be verified"
 msgstr ""
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6066,7 +6070,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr ""
@@ -6232,18 +6236,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/vi/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/vi/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/bikalabs/bika-lims/language/vi/)\n"

--- a/bika/lims/locales/zh/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/zh/LC_MESSAGES/bika.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Chinese (http://www.transifex.com/bikalabs/bika-lims/language/zh/)\n"
 "MIME-Version: 1.0\n"
@@ -174,6 +174,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -991,13 +995,13 @@ msgstr ""
 msgid "Calculation"
 msgstr "计算"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "计算公式"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "临时场地计算"
 
@@ -1050,11 +1054,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "已取消"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr ""
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr ""
 
@@ -1746,7 +1750,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1790,7 +1794,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "以来分析"
 
@@ -5162,11 +5166,11 @@ msgstr "温度"
 msgid "Template"
 msgstr "模板"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5408,7 +5412,7 @@ msgstr "识别导入文件的独特配置关键词. 这个词必须唯一, 并�
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "认证机构向实验室发放的参考码"
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5614,7 +5618,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "需要验证"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6070,7 +6074,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "值"
@@ -6236,18 +6240,6 @@ msgstr ""
 #. Default: "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 #: bika/lims/browser/templates/bika-frontpage.pt:20
 msgid "bika-frontpage-title"
-msgstr ""
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-msgid "calculation_formula_description"
 msgstr ""
 
 #: bika/lims/browser/reports/administration_usershistory.py:148

--- a/bika/lims/locales/zh/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/zh/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Chinese (http://www.transifex.com/bikalabs/bika-lims/language/zh/)\n"

--- a/bika/lims/locales/zh_CN/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/zh_CN/LC_MESSAGES/bika.po
@@ -18,8 +18,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/bikalabs/bika-lims/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
@@ -184,6 +184,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -1001,13 +1005,13 @@ msgstr "从不确定性进行精密计算"
 msgid "Calculation"
 msgstr "计算"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "计算公式"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "临时场地计算"
 
@@ -1060,11 +1064,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "已取消"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "无法激活计算，因为以下的服务依赖关系是无效的:${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "不能停用的计算，因它現正被以下服务使用中: ${calc_services}"
 
@@ -1756,7 +1760,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "定义方法的识别码。它必須是唯一的。"
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1800,7 +1804,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "以来分析"
 
@@ -5172,11 +5176,11 @@ msgstr "温度"
 msgid "Template"
 msgstr "模板"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5418,7 +5422,7 @@ msgstr "识别导入文件的独特配置关键词. 这个词必须唯一, 并�
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "认证机构向实验室发放的参考码"
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5624,7 +5628,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "需要验证"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6080,7 +6084,7 @@ msgid "Validator"
 msgstr "验证器;"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "值"
@@ -6249,19 +6253,6 @@ msgstr "bika-首页-描述"
 #, fuzzy
 msgid "bika-frontpage-title"
 msgstr "bika-首页-标题"
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "计算公式的描述"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/zh_CN/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/zh_CN/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/bikalabs/bika-lims/language/zh_CN/)\n"

--- a/bika/lims/locales/zh_TW/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/zh_TW/LC_MESSAGES/bika.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
-"PO-Revision-Date: 2017-03-17 08:09+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
+"PO-Revision-Date: 2017-03-25 17:35+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/bikalabs/bika-lims/language/zh_TW/)\n"
 "MIME-Version: 1.0\n"
@@ -172,6 +172,10 @@ msgid "<p>${service} requires the following services to be selected:</p><br/><p>
 msgstr ""
 
 msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
+msgstr ""
+
+#: bika/lims/content/calculation.py:84
+msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionsetupwidget.pt:33
@@ -989,13 +993,13 @@ msgstr "從不確定的進行精密計算"
 msgid "Calculation"
 msgstr "計算"
 
-#: bika/lims/content/calculation.py:71
+#: bika/lims/content/calculation.py:83
 msgid "Calculation Formula"
 msgstr "計算公式"
 
 #: bika/lims/content/analysis.py:98
 #: bika/lims/content/analysisservice.py:652
-#: bika/lims/content/calculation.py:39
+#: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "計算臨時場"
 
@@ -1048,11 +1052,11 @@ msgstr ""
 msgid "Cancelled"
 msgstr "已取消"
 
-#: bika/lims/content/calculation.py:269
+#: bika/lims/content/calculation.py:286
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
 msgstr "無法激活計算，因為下面的服務的依存關係是無效的:${inactive_services}"
 
-#: bika/lims/content/calculation.py:288
+#: bika/lims/content/calculation.py:305
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
 msgstr "不能停用的計算，因它現正被以下服務使用中: ${calc_services}"
 
@@ -1744,7 +1748,7 @@ msgstr ""
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "定義方法的識別碼。它必須是唯一的。"
 
-#: bika/lims/content/calculation.py:40
+#: bika/lims/content/calculation.py:50
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
@@ -1788,7 +1792,7 @@ msgid "Departments"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:155
-#: bika/lims/content/calculation.py:62
+#: bika/lims/content/calculation.py:73
 msgid "Dependent Analyses"
 msgstr "以來分析"
 
@@ -5160,11 +5164,11 @@ msgstr "温度"
 msgid "Template"
 msgstr "模板"
 
-#: bika/lims/content/calculation.py:95
+#: bika/lims/content/calculation.py:107
 msgid "Test Parameters"
 msgstr ""
 
-#: bika/lims/content/calculation.py:108
+#: bika/lims/content/calculation.py:121
 msgid "Test Result"
 msgstr ""
 
@@ -5406,7 +5410,7 @@ msgstr "該配置文件的關鍵字是用來唯一標識在導入文件。它必
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "認証機構向實驗室發放的參考碼"
 
-#: bika/lims/content/calculation.py:109
+#: bika/lims/content/calculation.py:122
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
@@ -5612,7 +5616,7 @@ msgstr ""
 msgid "To be verified"
 msgstr "需要驗証"
 
-#: bika/lims/content/calculation.py:96
+#: bika/lims/content/calculation.py:108
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 msgstr ""
 
@@ -6068,7 +6072,7 @@ msgid "Validator"
 msgstr "驗證"
 
 #: bika/lims/browser/worksheet/templates/results.pt:146
-#: bika/lims/content/calculation.py:90
+#: bika/lims/content/calculation.py:102
 #: bika/lims/content/instrument.py:196
 msgid "Value"
 msgstr "值"
@@ -6237,19 +6241,6 @@ msgstr "bika-頭版-描述"
 #, fuzzy
 msgid "bika-frontpage-title"
 msgstr "bika-頭版-標題"
-
-#. an analysis using this calculation is displayed.</p><p>To enter a
-#. Calculation, use standard maths operators,  + - * / ( ), and all keywords
-#. available, both from other Analysis Services and the Interim Fields
-#. specified here, as variables. Enclose them in square brackets [
-#. ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium
-#. (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where
-#. Ca and MG are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-#: bika/lims/content/calculation.py:72
-#, fuzzy
-msgid "calculation_formula_description"
-msgstr "計算_公式_說明"
 
 #: bika/lims/browser/reports/administration_usershistory.py:148
 msgid "comment"

--- a/bika/lims/locales/zh_TW/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/zh_TW/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-03-23 16:24+0000\n"
+"POT-Creation-Date: 2017-03-25 17:45+0000\n"
 "PO-Revision-Date: 2017-01-26 16:51+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/bikalabs/bika-lims/language/zh_TW/)\n"

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+Issue-1997: Calculation "Formula" field description keeps untranslated
 Issue-1981: Transifex Error processing bika/lims/skins/bika/bika_widgets/referencewidget.pt
 Issue-1975: Matching the labels to the fields is not easy when the user wants to add a single AR
 LIMS-2509: Correctly save empty values for CoordinateField and DurationField


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This field uses a description_msgid and the original text changed. The translated text was not dropped, because the msgid did not change, which resulted in a different amount of brackets in the translated text. This caused Transifex to mark the translation as fuzzy, and it was not translated. I will drop the description_msgid, so that further changes will not result in a similar broken translation state.

See https://github.com/bikalabs/bika.lims/issues/1997 for details.

## Current behavior before PR

Description of the Calculation Formula was untranslated because of the used `description_msgid`.

## Desired behavior after PR is merged

Description of the Calculation Formula get's translated according to its actual textual contents.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
