### PR TITLE
Issue-1999: Allow Python imports in calculation formulas

### DIFF
--- a/bika/lims/browser/js/bika.lims.calculation.edit.js
+++ b/bika/lims/browser/js/bika.lims.calculation.edit.js
@@ -44,6 +44,5 @@ function CalculationEditView() {
                 }
             });
         });
-    }
-
+    };
 }

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -714,11 +714,11 @@ class Analysis(BaseContent):
         formula = formula.replace('[', '%(').replace(']', ')f')
         try:
             formula = eval("'%s'%%mapping" % formula,
-                               {"__builtins__": None,
-                                'math': math,
-                                'context': self},
-                               {'mapping': mapping})
-            result = eval(formula)
+                           {"__builtins__": None,
+                            'math': math,
+                            'context': self},
+                           {'mapping': mapping})
+            result = eval(formula, calc._getGlobals())
         except TypeError:
             self.setResult("NA")
             return True
@@ -726,6 +726,9 @@ class Analysis(BaseContent):
             self.setResult('0/0')
             return True
         except KeyError as e:
+            self.setResult("NA")
+            return True
+        except ImportError as e:
             self.setResult("NA")
             return True
 

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -262,14 +262,14 @@ class Calculation(BaseFolder, HistoryAwareMixin):
 
         # Set default/existing values for InterimField keywords
         for interim in self.getInterimFields():
-            keyword = interim['keyword']
-            ex = [x['value'] for x in form_value if x['keyword'] == keyword]
+            keyword = interim.get('keyword')
+            ex = [x.get('value') for x in form_value if x.get('keyword') == keyword]
             params.append({'keyword': keyword,
-                          'value': ex[0] if ex else interim['value']})
+                          'value': ex[0] if ex else interim.get('value')})
         # Set existing/blank values for service keywords
         for service in self.getDependentServices():
             keyword = service.getKeyword()
-            ex = [x['value'] for x in form_value if x['keyword'] == keyword]
+            ex = [x.get('value') for x in form_value if x.get('keyword') == keyword]
             params.append({'keyword': keyword,
                           'value': ex[0] if ex else ''})
         self.Schema().getField('TestParameters').set(self, params)

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -282,6 +282,12 @@ class Calculation(BaseFolder, HistoryAwareMixin):
         mapping = {x['keyword']: x['value'] for x in self.getTestParameters()}
         # Gather up and parse formula
         formula = self.getMinifiedFormula()
+        test_result_field = self.Schema().getField('TestResult')
+
+        # Flush the TestResult field and return
+        if not formula:
+            return test_result_field.set(self, "")
+
         formula = formula.replace('[', '{').replace(']', '}').replace('  ', '')
         result = 'Failure'
 

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -8,6 +8,8 @@
 import re
 import sys
 import math
+import inspect
+import importlib
 
 import transaction
 from zope.interface import implements
@@ -71,6 +73,34 @@ schema = BikaSchema.copy() + Schema((
             checkbox_bound=0,
             visible=False,
             label=_("Dependent Analyses"),
+        ),
+    ),
+
+    RecordsField(
+        'PythonImports',
+        required=False,
+        subfields=('module', 'function'),
+        subfield_labels={'module': _('Module'), 'function': _('Function')},
+        subfield_readonly={'module': False, 'function': False},
+        subfield_types={'module': 'string', 'function': 'string'},
+        default=[
+            {'module': 'math', 'function': 'ceil'},
+            {'module': 'math', 'function': 'floor'},
+        ],
+        subfield_validators={
+            'module': 'importvalidator',
+        },
+        widget=RecordsWidget(
+            label=_("Additional Python Libraries"),
+            description=_(
+                "If your formula needs a special function from an external "
+                "Python library, you can import it here. E.g. if you want to "
+                "use the 'floor' function from the Python 'math' module, you "
+                "add 'math' to the Module field and 'floor' to the function field. "
+                "The equivalent in Python would be 'from math import floor'. "
+                "In your calculation you could use then 'floor([Ca] + [Mg])'. "
+            ),
+            allowDelete=True,
         ),
     ),
 
@@ -259,7 +289,7 @@ class Calculation(BaseFolder, HistoryAwareMixin):
             # print "pre: {}".format(formula)
             formula = formula.format(**mapping)
             # print "formatted: {}".format(formula)
-            result = eval(formula, {"__builtins__": None, 'math': math})
+            result = eval(formula, self._getGlobals())
             # print "result: {}".format(result)
         except TypeError as e:
             # non-numeric arguments in interim mapping?
@@ -268,9 +298,46 @@ class Calculation(BaseFolder, HistoryAwareMixin):
             result = "Division by 0: {}".format(str(e.args[0]))
         except KeyError as e:
             result = "Key Error: {}".format(str(e.args[0]))
+        except ImportError as e:
+            result = "Import Error: {}".format(str(e.args[0]))
         except Exception as e:
             result = "Unspecified exception: {}".format(str(e.args[0]))
-        self.Schema().getField('TestResult').set(self, str(result))
+        test_result_field.set(self, str(result))
+
+    def _getGlobals(self, **kwargs):
+        """Return the globals dictionary for the formula calculation
+        """
+        # Default globals
+        globs = {"__builtins__": None, 'math': math}
+        # Update with keyword arguments
+        globs.update(kwargs)
+        # Update with additional Python libraries
+        for imp in self.getPythonImports():
+            module = imp["module"]
+            func = imp["function"]
+            member = self._getModuleMember(module, func)
+            if member is None:
+                raise ImportError("Could not find member {} of module {}".format(
+                    func, module))
+            globs[func] = member
+        return globs
+
+    def _getModuleMember(self, dotted_name, member):
+        """Get the member object of a module.
+
+        :param dotted_name: The dotted name of the module, e.g. 'scipy.special'
+        :type dotted_name: string
+        :param member: The name of the member function, e.g. 'gammaincinv'
+        :type member: string
+        :returns: member object or None
+        """
+        try:
+            module = importlib.import_module(dotted_name)
+        except ImportError:
+            return None
+
+        members = dict(inspect.getmembers(module))
+        return members.get(member)
 
     def workflow_script_activate(self):
         wf = getToolByName(self, 'portal_workflow')

--- a/bika/lims/docs/Calculations.rst
+++ b/bika/lims/docs/Calculations.rst
@@ -1,0 +1,105 @@
+Calculations
+============
+
+Bika LIMS can dynamically calculate a value based on the results of several
+Analyses with a formula.
+
+Running this test from the buildout directory::
+
+    bin/Test test_textual_doctests -t Calculations
+
+
+Test Setup
+----------
+
+Needed Imports::
+
+    >>> import transaction
+    >>> from plone import api as ploneapi
+
+    >>> from bika.lims import api
+
+Functional Helpers::
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+
+Variables::
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bika_setup = portal.bika_setup
+    >>> bika_calculations = bika_setup.bika_calculations
+    >>> bika_analysisservices = bika_setup.bika_analysisservices
+
+
+Calculation
+-----------
+
+Calculations are created in the `bika_setup/bika_calculations` folder. They
+offer a `Formula` field, where keywords from Analyses can be used to calculate a
+result.
+
+Each `AnalysisService` contains a `Keyword` field, which can be referenced in a formula::
+
+    >>> as1 = api.create(bika_analysisservices, "AnalysisService", title="Calcium")
+    >>> as1.setKeyword("Ca")
+
+    >>> as2 = api.create(bika_analysisservices, "AnalysisService", title="Magnesium")
+    >>> as2.setKeyword("Mg")
+
+Test fixture::
+
+    >>> as1.reindexObject()
+    >>> as2.reindexObject()
+
+A `Calculation` is created in the `bika_setup.bika_calculations` folder::
+
+    >>> calc = api.create(bika_calculations, "Calculation", title="Total Hardness")
+
+The `Formula` field references the Keywords from Analysis Services::
+
+    >>> calc.setFormula("[Ca] + [Mg]")
+    >>> calc.getFormula()
+    '[Ca] + [Mg]'
+
+    >>> calc.getMinifiedFormula()
+    '[Ca] + [Mg]'
+
+The `Calculation` depends now on the two Analysis Services::
+
+    >>> calc.getCalculationDependencies()
+    {'...': {}, '...': {}}
+
+    >>> as1.set_Calculation(calc)
+    >>> calc.getCalculationDependants()
+    [<AnalysisService at /plone/bika_setup/bika_analysisservices/analysisservice-1>]
+
+The `Formula` can be tested with dummy values in the `TestParameters` field::
+
+    >>> form_value = [{"keyword": "Ca", "value": 5.6}, {"keyword": "Mg", "value": 3.3},]
+    >>> calc.setTestParameters(form_value)
+    >>> calc.setTestResult(form_value)
+    >>> calc.getTestResult()
+    '8.9'
+
+Within a `Calculation` it is also possible to use a Python function to calculate
+a result. The user can add a Python `module` as a dotted name and a member
+function in the `PythonImports` field::
+
+    >>> calc.setPythonImports([{'module': 'math', 'function': 'floor'}])
+    >>> calc.setFormula("floor([Ca] + [Mg])")
+    >>> calc.getFormula()
+    'floor([Ca] + [Mg])'
+
+    >>> calc.setTestResult(form_value)
+    >>> calc.getTestResult()
+    '8.0'
+
+A `Calculation` can therefore dynamically get a module and a member::
+
+    >>> calc._getModuleMember('math', 'ceil')
+    <built-in function ceil>

--- a/bika/lims/docs/Calculations.rst
+++ b/bika/lims/docs/Calculations.rst
@@ -71,8 +71,10 @@ The `Formula` field references the Keywords from Analysis Services::
 
 The `Calculation` depends now on the two Analysis Services::
 
-    >>> calc.getCalculationDependencies()
-    {'...': {}, '...': {}}
+    >>> sorted(calc.getCalculationDependencies(flat=True))
+    [<AnalysisService at /plone/bika_setup/bika_analysisservices/analysisservice-1>, <AnalysisService at /plone/bika_setup/bika_analysisservices/analysisservice-2>]
+
+It is also possible to find out if an `AnalysisService` depends on the calculation::
 
     >>> as1.set_Calculation(calc)
     >>> calc.getCalculationDependants()

--- a/bika/lims/tests/test_textual_doctests.py
+++ b/bika/lims/tests/test_textual_doctests.py
@@ -21,6 +21,7 @@ DOCTESTS = [
     "../docs/ContactUser.rst",
     "../docs/Instruments.rst",
     "../docs/Versioning.rst",
+    "../docs/Calculations.rst",
 ]
 
 

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -1100,3 +1100,27 @@ class SortKeyValidator:
 
 
 validation.register(SortKeyValidator())
+
+
+class ImportValidator:
+    """Checks if a dotted name can be imported or not
+    """
+    implements(IValidator)
+    name = "importvalidator"
+
+    def __call__(self, module, **kwargs):
+
+        # some needed tools
+        instance = kwargs['instance']
+        translate = getToolByName(instance, 'translation_service').translate
+
+        try:
+            import importlib
+            importlib.import_module(module)
+        except ImportError:
+            msg = _("Validation failed: Could not import module '%s'" % module)
+            return to_utf8(translate(msg))
+
+        return True
+
+validation.register(ImportValidator())

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1 (unreleased)
 ------------------
 
+Issue-1999: Allow external Python library functions to be used in Calculation Formulas
 Issue-1971: Allow Reports in Landscape
 Issue-1997: Calculation "Formula" field description keeps untranslated
 Issue-1981: Transifex Error processing bika/lims/skins/bika/bika_widgets/referencewidget.pt


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

See https://github.com/bikalabs/bika.lims/issues/1999 for details.

## Current behavior before PR

External library functions like `scipy.special.gammaincinv` could not be used in Calculation formulas.

## Desired behavior after PR is merged

The user can use external functions in calculation formulas (as long as the import is in the `sys.path` of the Bika LIMS server). This opens also the door for custom functions available in the `sys.path`.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
