### PR TITLE
On the set_state variable we not setting the default value

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -2465,9 +2465,13 @@ function AnalysisRequestAddByCol() {
                    var arnum = $(e).parents("[arnum]").attr("arnum")
                    var fieldname = $(e).parents("[fieldname]").attr("fieldname")
                    var value = $(e).attr("uid")
-                     ? $(e).attr("uid")
-                     : $(e).val()
-                   state_set(arnum, fieldname, value)
+                   if (value){
+                       state_set(arnum, fieldname, value)
+                   }
+                   //var value = $(e).attr("uid")
+                   //  ? $(e).attr("uid")
+                   //  : $(e).val()
+                   //state_set(arnum, fieldname, value)
                })
         // checkboxes inside ar_add_widget table.
         $.each($('[ar_add_ar_widget] input[type="checkbox"]').not('[class^="rejectionwidget-checkbox"]'),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
https://github.com/bikalabs/bika.lims/issues/1995


## Current behavior before PR
CC contacts not saving during AR creation
On saving of the form, the method set_state  sets CCContact value to an empty string
because the UID does not get set on the HTML(This happens for MutliValue on the ReferenceWidget)

## Desired behavior after PR is merged
CC contacts are saved on AR creation
The change made is only to use set_state if  there's a UID and  don't default value to an empty string

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
