### PR TITLE
Fixed BatchID getter

### DIFF
--- a/bika/lims/content/batch.py
+++ b/bika/lims/content/batch.py
@@ -192,10 +192,10 @@ schema = BikaFolderSchema.copy() + Schema((
 )
 )
 
-
+schema['BatchID'].widget.description = _("If no value is entered, the Batch ID will be auto-generated.")
 schema['title'].required = False
 schema['title'].widget.visible = True
-schema['title'].widget.description = _("If no Title value is entered, the Batch ID will be used.")
+schema['title'].widget.description = _("If no value is entered, the Batch ID will be used.")
 schema['description'].required = False
 schema['description'].widget.visible = True
 
@@ -290,7 +290,9 @@ class Batch(ATFolder):
     security.declarePublic('getBatchID')
 
     def getBatchID(self):
-        if self.BatchID != '':
+        if self.BatchID:
+            return self.BatchID
+        if self.checkCreationFlag():
             return self.BatchID
         return self.getId()
 


### PR DESCRIPTION
When creating a batch, the BatchID field was being auto filled by the temporary object ID (eg. "batch.2017-04-18.0689260719")
fixes:
https://jira.bikalabs.com/browse/LIMS-2632 (Created Batches do not use ID server)
also accomodates:
https://jira.bikalabs.com/browse/LIMS-2065 (WIP: Display Lab Batch ID on Batch view page)

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
