### PR TITLE
fix ar copy button on dropdown/select

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -697,10 +697,10 @@ function AnalysisRequestAddByCol() {
             }
             // select element
             else if ($(td1).find('select').length > 0) {
-                var input = $(td1).find('.rejectionwidget-input-other').val();
+                var input = $(td1).find('select').val();
                 for (var arnum = 1; arnum < nr_ars; arnum++) {
                     td = $(tr).find('td[arnum="' + arnum + '"]')[0];
-                    e = $(td).find('.rejectionwidget-input-other')[0];
+                    e = $(td).find('select')[0];
                     $(e).val(input);
                     $(e).trigger('copy');
                 }


### PR DESCRIPTION
Fixed:
when pressing the >> button for the Sampler row, all the columns should be completed as for the others
https://jira.bikalabs.com/browse/LIMS-2633


--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
