### PR TITLE
Lims 1833 instrument import screen tidying

### DIFF
--- a/bika/lims/browser/css/instrument_import.css
+++ b/bika/lims/browser/css/instrument_import.css
@@ -1,0 +1,22 @@
+/* Stylesheet for the 'bika' Plone theme */
+/*Instrument Impor*/
+td.instrument-import {
+    padding-bottom: 20px;
+    white-space: nowrap;
+}
+td.instrument-import-selector{
+    vertical-align:top;
+    padding-right:30px;
+    padding-top:10px;
+}
+td.instrument-import-padding-top{
+    padding-top:10px;
+}
+tr.instrument-import-border-top{
+    border-top: 1px black solid;
+}
+p.instrument-import-paragraph{
+    color: #3F3F3F;
+    font-size: 0.87em;
+}
+/**/

--- a/bika/lims/exportimport/instruments/abaxis/vetscan/vs2_import.pt
+++ b/bika/lims/exportimport/instruments/abaxis/vetscan/vs2_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/abaxis/vetscan/vs2_import.pt
+++ b/bika/lims/exportimport/instruments/abaxis/vetscan/vs2_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='data_file'>File</label>&nbsp;
+    <label i18n:translate="" for='data_file'>File</label>&nbsp;
     <input type="file" name="data_file" id="data_file"/>
     &nbsp;&nbsp;
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"

--- a/bika/lims/exportimport/instruments/agilent/masshunter/quantitative_import.pt
+++ b/bika/lims/exportimport/instruments/agilent/masshunter/quantitative_import.pt
@@ -24,8 +24,8 @@
         </tr>
   -->
         <tr>
-            <td><label for="amhq_artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="amhq_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="amhq_artoapply" id="amhq_artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -33,8 +33,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="amhq_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="amhq_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="amhq_override" id="amhq_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -43,15 +43,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="amhq_instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="amhq_instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="amhq_instrument" id="amhq_instrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/agilent/masshunter/quantitative_import.pt
+++ b/bika/lims/exportimport/instruments/agilent/masshunter/quantitative_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='amhq_file'>File</label>&nbsp;
+    <label i18n:translate="" for='amhq_file'>File</label>&nbsp;
     <input type="file" name="amhq_file" id="amhq_file"/>
     &nbsp;&nbsp;
-    <label for='amhq_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='amhq_format'>Format</label>&nbsp;
     <select name="amhq_format" id="amhq_format">
         <option value='csv'>CSV</option>
     </select>
@@ -12,7 +12,7 @@
     <table cellpadding="0" cellspacing="0">
  <!--
         <tr>
-            <td><label for="amhq_sample">Sample search</label></td>
+            <td><label i18n:translate="" for="amhq_sample">Sample search</label></td>
             <td>
                 <select name="amhq_sample" id="amhq_sample">
                     <option value="requestid">Analysis Request ID</option>
@@ -24,7 +24,7 @@
         </tr>
   -->
         <tr>
-            <td class="instrument-import"><label for="amhq_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="amhq_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="amhq_artoapply" id="amhq_artoapply">
                     <option value="received">Received</option>
@@ -33,7 +33,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="amhq_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="amhq_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="amhq_override" id="amhq_override">
                     <option value="nooverride">Don't override results</option>
@@ -44,18 +44,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="amhq_instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="amhq_instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="amhq_instrument" id="amhq_instrument"

--- a/bika/lims/exportimport/instruments/alere/pima/beads_import.pt
+++ b/bika/lims/exportimport/instruments/alere/pima/beads_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="alere_pima_beads_artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="alere_pima_beads_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="alere_pima_beads_artoapply" id="alere_pima_beads_artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="alere_pima_beads_file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="alere_pima_beads_file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="alere_pima_beads_override" id="alere_pima_beads_file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="alere_pima_beads_instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="alere_pima_beads_instrument" id="alere_pima_beads_fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/alere/pima/beads_import.pt
+++ b/bika/lims/exportimport/instruments/alere/pima/beads_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='alere_pima_beads_file'>File</label>&nbsp;
+    <label i18n:translate="" for='alere_pima_beads_file'>File</label>&nbsp;
     <input type="file" name="alere_pima_beads_file" id="alere_pima_beads_file"/>
     &nbsp;&nbsp;
-    <label for='alere_pima_beads_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='alere_pima_beads_format'>Format</label>&nbsp;
     <select name="alere_pima_beads_format" id="alere_pima_beads_format">
         <option value='slk'>SLK</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="alere_pima_beads_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="alere_pima_beads_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="alere_pima_beads_artoapply" id="alere_pima_beads_artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="alere_pima_beads_file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="alere_pima_beads_file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="alere_pima_beads_override" id="alere_pima_beads_file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="alere_pima_beads_instrument" id="alere_pima_beads_fileinstrument"

--- a/bika/lims/exportimport/instruments/alere/pima/cd4_import.pt
+++ b/bika/lims/exportimport/instruments/alere/pima/cd4_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="alere_pima_cd4_artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="alere_pima_cd4_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="alere_pima_cd4_artoapply" id="alere_pima_cd4_artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="alere_pima_cd4_file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="alere_pima_cd4_file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="alere_pima_cd4_override" id="alere_pima_cd4_file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="alere_pima_cd4_instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="alere_pima_cd4_instrument" id="alere_pima_cd4_fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/alere/pima/cd4_import.pt
+++ b/bika/lims/exportimport/instruments/alere/pima/cd4_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='alere_pima_cd4_file'>File</label>&nbsp;
+    <label i18n:translate="" for='alere_pima_cd4_file'>File</label>&nbsp;
     <input type="file" name="alere_pima_cd4_file" id="alere_pima_cd4_file"/>
     &nbsp;&nbsp;
-    <label for='alere_pima_cd4_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='alere_pima_cd4_format'>Format</label>&nbsp;
     <select name="alere_pima_cd4_format" id="alere_pima_cd4_format">
         <option value='slk'>SLK</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="alere_pima_cd4_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="alere_pima_cd4_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="alere_pima_cd4_artoapply" id="alere_pima_cd4_artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="alere_pima_cd4_file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="alere_pima_cd4_file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="alere_pima_cd4_override" id="alere_pima_cd4_file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="alere_pima_cd4_instrument" id="alere_pima_cd4_fileinstrument"

--- a/bika/lims/exportimport/instruments/beckmancoulter/access/model2_import.pt
+++ b/bika/lims/exportimport/instruments/beckmancoulter/access/model2_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='beckmancoulter_access_model2_file'>File</label>&nbsp;
+    <label i18n:translate="" for='beckmancoulter_access_model2_file'>File</label>&nbsp;
     <input type="file" name="beckmancoulter_access_model2_file" id="beckmancoulter_access_model2_file"/>
     &nbsp;&nbsp;
-    <label for='beckmancoulter_access_model2_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='beckmancoulter_access_model2_format'>Format</label>&nbsp;
     <select name="beckmancoulter_access_model2_format" id="beckmancoulter_access_model2_format">
         <option value='csv'>CSV</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="beckmancoulter_access_model2_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="beckmancoulter_access_model2_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="beckmancoulter_access_model2_artoapply" id="beckmancoulter_access_model2_artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="beckmancoulter_access_model2_file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="beckmancoulter_access_model2_file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="beckmancoulter_access_model2_override" id="beckmancoulter_access_model2_file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="beckmancoulter_access_model2_instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="beckmancoulter_access_model2_instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="beckmancoulter_access_model2_instrument" id="beckmancoulter_access_model2_fileinstrument"

--- a/bika/lims/exportimport/instruments/beckmancoulter/access/model2_import.pt
+++ b/bika/lims/exportimport/instruments/beckmancoulter/access/model2_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="beckmancoulter_access_model2_artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="beckmancoulter_access_model2_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="beckmancoulter_access_model2_artoapply" id="beckmancoulter_access_model2_artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="beckmancoulter_access_model2_file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="beckmancoulter_access_model2_file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="beckmancoulter_access_model2_override" id="beckmancoulter_access_model2_file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="beckmancoulter_access_model2_instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="beckmancoulter_access_model2_instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="beckmancoulter_access_model2_instrument" id="beckmancoulter_access_model2_fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/biodrop/ulite/ulite_import.pt
+++ b/bika/lims/exportimport/instruments/biodrop/ulite/ulite_import.pt
@@ -25,10 +25,8 @@
     <h3 style='margin-bottom:10px;margin-top:10px;'>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-
-            <!-- Allowed states of the analysis requests to look for -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -36,10 +34,8 @@
             </td>
         </tr>
         <tr>
-
-            <!-- Results overriding -->
-            <td><label for="override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="override" id="override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -48,16 +44,20 @@
             </td>
         </tr>
         <tr>
-
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="instrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/biodrop/ulite/ulite_import.pt
+++ b/bika/lims/exportimport/instruments/biodrop/ulite/ulite_import.pt
@@ -1,7 +1,7 @@
     <p></p>
 
     <!-- Analysis service to apply the results -->
-    <label for='analysis'>Analysis Service</label>
+    <label i18n:translate="" for='analysis'>Analysis Service</label>
     <select name="analysis" id="analysis" tal:define="analysislist view/getAnalysisServicesDisplayList">
         <tal:options repeat="option analysislist">
         <option tal:attributes="value python:option;"
@@ -11,12 +11,12 @@
     <p></p>
 
     <!-- Input file selector -->
-    <label for='filename'>File</label>&nbsp;
+    <label i18n:translate="" for='filename'>File</label>&nbsp;
     <input type="file" name="filename" id="filename"/>
     &nbsp;&nbsp;
 
     <!-- Format file selector -->
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -25,7 +25,7 @@
     <h3 style='margin-bottom:10px;margin-top:10px;'>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -34,7 +34,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="override">Results override</label></td>
             <td class="instrument-import">
                 <select name="override" id="override">
                     <option value="nooverride">Don't override results</option>
@@ -45,18 +45,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="instrument"

--- a/bika/lims/exportimport/instruments/eltra/cs/cs2000_import.pt
+++ b/bika/lims/exportimport/instruments/eltra/cs/cs2000_import.pt
@@ -1,7 +1,7 @@
     <p></p>
 
     <!-- Analysis services to apply the results -->
-    <label for='analysis'>Analysis Service in the first column</label>
+    <label i18n:translate="" for='analysis'>Analysis Service in the first column</label>
     <select name="analysis1" id="analysis1" tal:define="analysislist view/getAnalysisServicesDisplayList">
         <tal:options repeat="option analysislist">
         <option tal:attributes="value python:option;"
@@ -10,7 +10,7 @@
     </select>
 
     <p></p>
-    <label for='analysis'>Analysis Service in the second column</label>
+    <label i18n:translate="" for='analysis'>Analysis Service in the second column</label>
     <select name="analysis2" id="analysis2" tal:define="analysislist view/getAnalysisServicesDisplayList">
         <tal:options repeat="option analysislist">
         <option tal:attributes="value python:option;"
@@ -22,10 +22,10 @@
     </p>
     <p></p>
 
-    <label for='data_file'>File</label>&nbsp;
+    <label i18n:translate="" for='data_file'>File</label>&nbsp;
     <input type="file" name="data_file" id="data_file"/>
     &nbsp;&nbsp;
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='tsv'>TSV</option>
     </select>
@@ -33,7 +33,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -42,7 +42,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
@@ -53,18 +53,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"

--- a/bika/lims/exportimport/instruments/eltra/cs/cs2000_import.pt
+++ b/bika/lims/exportimport/instruments/eltra/cs/cs2000_import.pt
@@ -9,6 +9,7 @@
         </tal:options>
     </select>
 
+    <p></p>
     <label for='analysis'>Analysis Service in the second column</label>
     <select name="analysis2" id="analysis2" tal:define="analysislist view/getAnalysisServicesDisplayList">
         <tal:options repeat="option analysislist">
@@ -32,8 +33,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -41,8 +42,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -51,15 +52,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/foss/fiastar/fiastar_import.pt
+++ b/bika/lims/exportimport/instruments/foss/fiastar/fiastar_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/foss/fiastar/fiastar_import.pt
+++ b/bika/lims/exportimport/instruments/foss/fiastar/fiastar_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='data_file'>File</label>&nbsp;
+    <label i18n:translate="" for='data_file'>File</label>&nbsp;
     <input type="file" name="data_file" id="data_file"/>
     &nbsp;&nbsp;
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"

--- a/bika/lims/exportimport/instruments/foss/winescan/auto_import.pt
+++ b/bika/lims/exportimport/instruments/foss/winescan/auto_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='wsa_file'>File</label>&nbsp;
+    <label i18n:translate="" for='wsa_file'>File</label>&nbsp;
     <input type="file" name="wsa_file" id="wsa_file"/>
     &nbsp;&nbsp;
-    <label for='wsa_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='wsa_format'>Format</label>&nbsp;
     <select name="wsa_format" id="wsa_format">
         <option value='csv'>CSV</option>
     </select>
@@ -12,7 +12,7 @@
     <table cellpadding="0" cellspacing="0">
  <!--
         <tr>
-            <td><label for="wsa_sample">Sample search</label></td>
+            <td><label i18n:translate="" for="wsa_sample">Sample search</label></td>
             <td>
                 <select name="wsa_sample" id="wsa_sample">
                     <option value="requestid">Analysis Request ID</option>
@@ -24,7 +24,7 @@
         </tr>
   -->
         <tr>
-            <td class="instrument-import"><label for="wsa_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="wsa_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="wsa_artoapply" id="wsa_artoapply">
                     <option value="received">Received</option>
@@ -33,7 +33,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="wsa_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="wsa_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="wsa_override" id="wsa_override">
                     <option value="nooverride">Don't override results</option>
@@ -44,18 +44,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="wsa_instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="wsa_instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="wsa_instrument" id="wsa_instrument"

--- a/bika/lims/exportimport/instruments/foss/winescan/auto_import.pt
+++ b/bika/lims/exportimport/instruments/foss/winescan/auto_import.pt
@@ -24,8 +24,8 @@
         </tr>
   -->
         <tr>
-            <td><label for="wsa_artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="wsa_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="wsa_artoapply" id="wsa_artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -33,8 +33,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="wsa_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="wsa_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="wsa_override" id="wsa_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -43,15 +43,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="wsa_instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="wsa_instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="wsa_instrument" id="wsa_instrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/foss/winescan/ft120_import.pt
+++ b/bika/lims/exportimport/instruments/foss/winescan/ft120_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='wsf_file'>File</label>&nbsp;
+    <label i18n:translate="" for='wsf_file'>File</label>&nbsp;
     <input type="file" name="wsf_file" id="wsf_file"/>
     &nbsp;&nbsp;
-    <label for='wsf_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='wsf_format'>Format</label>&nbsp;
     <select name="wsf_format" id="wsf_format">
         <option value='csv'>CSV</option>
     </select>
@@ -12,7 +12,7 @@
     <table cellpadding="0" cellspacing="0">
  <!--
         <tr>
-            <td><label for="wsf_sample">Sample search</label></td>
+            <td><label i18n:translate="" for="wsf_sample">Sample search</label></td>
             <td>
                 <select name="wsf_sample" id="wsf_sample">
                     <option value="requestid">Analysis Request ID</option>
@@ -24,7 +24,7 @@
         </tr>
   -->
         <tr>
-            <td class="instrument-import"><label for="wsf_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="wsf_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="wsf_artoapply" id="wsf_artoapply">
                     <option value="received">Received</option>
@@ -33,7 +33,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="wsf_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="wsf_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="wsf_override" id="wsf_override">
                     <option value="nooverride">Don't override results</option>
@@ -44,18 +44,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="wsf_instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="wsf_instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="wsf_instrument" id="wsf_instrument"

--- a/bika/lims/exportimport/instruments/foss/winescan/ft120_import.pt
+++ b/bika/lims/exportimport/instruments/foss/winescan/ft120_import.pt
@@ -24,8 +24,8 @@
         </tr>
   -->
         <tr>
-            <td style='vertical-align:top;padding-right:30px;'><label for="wsf_artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="wsf_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="wsf_artoapply" id="wsf_artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -33,8 +33,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="wsf_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="wsf_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="wsf_override" id="wsf_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -43,15 +43,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="wsf_instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="wsf_instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="wsf_instrument" id="wsf_instrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/generic/xml_import.pt
+++ b/bika/lims/exportimport/instruments/generic/xml_import.pt
@@ -1,6 +1,6 @@
 
     <p></p>
-	<label for='xml_file'>File</label>&nbsp;
+	<label i18n:translate="" for='xml_file'>File</label>&nbsp;
     <input type="file" name="xml_file" id="xml_file"/>
     &nbsp;&nbsp;
 	<input name="firstsubmit" type="submit" value="Submit" i18n:attributes="value"/>

--- a/bika/lims/exportimport/instruments/horiba/jobinyvon/icp_import.pt
+++ b/bika/lims/exportimport/instruments/horiba/jobinyvon/icp_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/horiba/jobinyvon/icp_import.pt
+++ b/bika/lims/exportimport/instruments/horiba/jobinyvon/icp_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='data_file'>File</label>&nbsp;
+    <label i18n:translate="" for='data_file'>File</label>&nbsp;
     <input type="file" name="data_file" id="data_file"/>
     &nbsp;&nbsp;
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"

--- a/bika/lims/exportimport/instruments/instrument.pt
+++ b/bika/lims/exportimport/instruments/instrument.pt
@@ -1,7 +1,7 @@
 <p></p>
-<label for='instrument_results_file'>File</label>&nbsp;
+<label i18n:translate="" for='instrument_results_file'>File</label>&nbsp;
 <input type="file" name="instrument_results_file" id="instrument_results_file"/>&nbsp;&nbsp;
-<label for='instrument_results_file_format'>Format</label>&nbsp;
+<label i18n:translate="" for='instrument_results_file_format'>Format</label>&nbsp;
 <select name="instrument_results_file_format" id="instrument_results_file_format">
     <option value='csv'>CSV</option>
 </select>
@@ -9,7 +9,7 @@
 <h3>Advanced options</h3>
 <table cellpadding="0" cellspacing="0">
     <tr>
-        <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+        <td class="instrument-import"><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
         <td class="instrument-import">
             <select name="artoapply" id="artoapply">
                 <option value="received">Received</option>
@@ -18,7 +18,7 @@
         </td>
     </tr>
     <tr>
-        <td class="instrument-import"><label for="file_override">Results override</label></td>
+        <td class="instrument-import"><label i18n:translate="" for="file_override">Results override</label></td>
         <td class="instrument-import">
             <select name="override" id="file_override">
                 <option value="nooverride">Don't override results</option>
@@ -29,11 +29,11 @@
     </tr>
     <tr>
         <td colspan=2>
-          <label for="title">Instrument Calibration Import</label>
+          <label i18n:translate="" for="title">Instrument Calibration Import</label>
         </td>
     </tr>
     <tr class="instrument-import-border-top">
-        <td class="instrument-import-selector"><label for="qcinstrument">Instrument</label></td>
+        <td class="instrument-import-selector"><label i18n:translate="" for="qcinstrument">Instrument</label></td>
         <td class="instrument-import-padding-top">
             <select name="qcinstrument" id="qcinstrument"
                     tal:define="instrlist view/getInstruments">
@@ -44,9 +44,9 @@
             </select>
             <p i18n:translate="" class="instrument-import-paragraph">
                 If an imported result does not match Analysis Requests, Samples,
-                Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                 When a matching Reference Sample ID is found, the system automatically creates
-                a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                 If no instrument is selected, no Calibration tests will be created for orphan IDs.
             </p>
         </td>

--- a/bika/lims/exportimport/instruments/instrument.pt
+++ b/bika/lims/exportimport/instruments/instrument.pt
@@ -9,8 +9,8 @@
 <h3>Advanced options</h3>
 <table cellpadding="0" cellspacing="0">
     <tr>
-        <td><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
-        <td>
+        <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+        <td class="instrument-import">
             <select name="artoapply" id="artoapply">
                 <option value="received">Received</option>
                 <option value="received_tobeverified">Received and to be verified</option>
@@ -18,9 +18,9 @@
         </td>
     </tr>
     <tr>
-        <td><label for="results_override">Results override</label></td>
-        <td>
-            <select name="results_override" id="results_override">
+        <td class="instrument-import"><label for="file_override">Results override</label></td>
+        <td class="instrument-import">
+            <select name="override" id="file_override">
                 <option value="nooverride">Don't override results</option>
                 <option value="override">Override non-empty results</option>
                 <option value="overrideempty">Override non-empty results (also with empty)</option>
@@ -28,8 +28,13 @@
         </td>
     </tr>
     <tr>
-        <td style='vertical-align:top;padding-right:30px;'><label for="qcinstrument">Instrument</label></td>
-        <td>
+        <td colspan=2>
+          <label for="title">Instrument Calibration Import</label>
+        </td>
+    </tr>
+    <tr class="instrument-import-border-top">
+        <td class="instrument-import-selector"><label for="qcinstrument">Instrument</label></td>
+        <td class="instrument-import-padding-top">
             <select name="qcinstrument" id="qcinstrument"
                     tal:define="instrlist view/getInstruments">
                 <tal:options repeat="option instrlist">
@@ -37,9 +42,12 @@
                         tal:content="python:instrlist.getValue(option)"/>
                 </tal:options>
             </select>
-            <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate), it will use the record's identifier to find matches with Reference Sample IDs. If a Reference Sample ID is found, the system will automatically create a Calibration Test (Reference Analysis) and will link it to the selected Instrument above.<br/>
-                If no instrument selected, any Calibration Test will be created for orphan IDs.
+            <p i18n:translate="" class="instrument-import-paragraph">
+                If an imported result does not match Analysis Requests, Samples,
+                Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                When a matching Reference Sample ID is found, the system automatically creates
+                a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                If no instrument is selected, no Calibration tests will be created for orphan IDs.
             </p>
         </td>
     </tr>

--- a/bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit_import.pt
+++ b/bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit_import.pt
@@ -25,10 +25,8 @@
     <h3 style='margin-bottom:10px;margin-top:10px;'>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-
-            <!-- Allowed states of the analysis requests to look for -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -36,10 +34,8 @@
             </td>
         </tr>
         <tr>
-
-            <!-- Results overriding -->
-            <td><label for="override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="override" id="override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -48,16 +44,20 @@
             </td>
         </tr>
         <tr>
-
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="instrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit_import.pt
+++ b/bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit_import.pt
@@ -1,7 +1,7 @@
     <p></p>
 
     <!-- Analysis service to apply the results -->
-    <label for='analysis'>Analysis Service</label>
+    <label i18n:translate="" for='analysis'>Analysis Service</label>
     <select name="analysis" id="analysis" tal:define="analysislist view/getAnalysisServicesDisplayList">
         <tal:options repeat="option analysislist">
         <option tal:attributes="value python:option;"
@@ -11,12 +11,12 @@
     <p></p>
 
     <!-- Input file selector -->
-    <label for='filename'>File</label>&nbsp;
+    <label i18n:translate="" for='filename'>File</label>&nbsp;
     <input type="file" name="filename" id="filename"/>
     &nbsp;&nbsp;
 
     <!-- Format file selector -->
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -25,7 +25,7 @@
     <h3 style='margin-bottom:10px;margin-top:10px;'>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -34,7 +34,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="override">Results override</label></td>
             <td class="instrument-import">
                 <select name="override" id="override">
                     <option value="nooverride">Don't override results</option>
@@ -45,18 +45,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="instrument"

--- a/bika/lims/exportimport/instruments/nuclisens/easyq_import.pt
+++ b/bika/lims/exportimport/instruments/nuclisens/easyq_import.pt
@@ -1,8 +1,8 @@
 <p></p>
-<label for="nuclisens_easyq_file">File</label>&nbsp;
+<label i18n:translate="" for="nuclisens_easyq_file">File</label>&nbsp;
 <input type="file" name="nuclisens_easyq_file" id="nuclisens_easyq_file"/>
 &nbsp;&nbsp;
-<label for="nuclisens_easyq_format">Format</label>&nbsp;
+<label i18n:translate="" for="nuclisens_easyq_format">Format</label>&nbsp;
 <select name="nuclisens_easyq_format" id="nuclisens_easyq_format">
     <option value='xlsx'>XLSX</option>
 </select>
@@ -10,7 +10,7 @@
 <h3>Advanced options</h3>
 <table cellpadding="0" cellspacing="0">
     <tr>
-        <td class="instrument-import"><label for="nuclisens_easyq_artoapply">Analysis Requests state</label>&nbsp;</td>
+        <td class="instrument-import"><label i18n:translate="" for="nuclisens_easyq_artoapply">Analysis Requests state</label>&nbsp;</td>
         <td class="instrument-import">
             <select name="nuclisens_easyq_artoapply" id="nuclisens_easyq_artoapply">
                 <option value="received">Received</option>
@@ -19,7 +19,7 @@
         </td>
     </tr>
     <tr>
-        <td class="instrument-import"><label for="nuclisens_easyq_override">Results override</label></td>
+        <td class="instrument-import"><label i18n:translate="" for="nuclisens_easyq_override">Results override</label></td>
         <td class="instrument-import">
             <select name="nuclisens_easyq_override" id="nuclisens_easyq_override">
                 <option value="nooverride">Don't override results</option>
@@ -30,18 +30,18 @@
     </tr>
     <tr>
         <td colspan=2>
-          <label for="title">Instrument Calibration Import</label>
+          <label i18n:translate="" for="title">Instrument Calibration Import</label>
         </td>
     </tr>
     <tr class="instrument-import-border-top">
         <!-- Instrument selector. For calibration tests -->
-        <td class="instrument-import-selector"><label for="nuclisens_easyq_instrument">Instrument</label></td>
+        <td class="instrument-import-selector"><label i18n:translate="" for="nuclisens_easyq_instrument">Instrument</label></td>
         <td class="instrument-import-padding-top">
             <p i18n:translate="" class="instrument-import-paragraph">
                 If an imported result does not match Analysis Requests, Samples,
-                Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                 When a matching Reference Sample ID is found, the system automatically creates
-                a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                 If no instrument is selected, no Calibration tests will be created for orphan IDs.
             </p>
             <select name="nuclisens_easyq_instrument" id="nuclisens_easyq_instrument"

--- a/bika/lims/exportimport/instruments/nuclisens/easyq_import.pt
+++ b/bika/lims/exportimport/instruments/nuclisens/easyq_import.pt
@@ -10,8 +10,8 @@
 <h3>Advanced options</h3>
 <table cellpadding="0" cellspacing="0">
     <tr>
-        <td><label for="nuclisens_easyq_artoapply">Analysis Requests state</label>&nbsp;</td>
-        <td>
+        <td class="instrument-import"><label for="nuclisens_easyq_artoapply">Analysis Requests state</label>&nbsp;</td>
+        <td class="instrument-import">
             <select name="nuclisens_easyq_artoapply" id="nuclisens_easyq_artoapply">
                 <option value="received">Received</option>
                 <option value="received_tobeverified">Received and to be verified</option>
@@ -19,8 +19,8 @@
         </td>
     </tr>
     <tr>
-        <td><label for="nuclisens_easyq_override">Results override</label></td>
-        <td>
+        <td class="instrument-import"><label for="nuclisens_easyq_override">Results override</label></td>
+        <td class="instrument-import">
             <select name="nuclisens_easyq_override" id="nuclisens_easyq_override">
                 <option value="nooverride">Don't override results</option>
                 <option value="override">Override non-empty results</option>
@@ -29,11 +29,20 @@
         </td>
     </tr>
     <tr>
+        <td colspan=2>
+          <label for="title">Instrument Calibration Import</label>
+        </td>
+    </tr>
+    <tr class="instrument-import-border-top">
         <!-- Instrument selector. For calibration tests -->
-        <td style='vertical-align:top;padding-right:30px;'><label for="nuclisens_easyq_instrument">Instrument</label></td>
-        <td>
-            <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-               relevant text for the instrument to be added soon. 
+        <td class="instrument-import-selector"><label for="nuclisens_easyq_instrument">Instrument</label></td>
+        <td class="instrument-import-padding-top">
+            <p i18n:translate="" class="instrument-import-paragraph">
+                If an imported result does not match Analysis Requests, Samples,
+                Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                When a matching Reference Sample ID is found, the system automatically creates
+                a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                If no instrument is selected, no Calibration tests will be created for orphan IDs.
             </p>
             <select name="nuclisens_easyq_instrument" id="nuclisens_easyq_instrument"
                     tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf_import.pt
+++ b/bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='panalytical_omnia_axios_file'>File</label>&nbsp;
+    <label i18n:translate="" for='panalytical_omnia_axios_file'>File</label>&nbsp;
     <input type="file" name="panalytical_omnia_axios_file" id="panalytical_omnia_axios_file"/>
     &nbsp;&nbsp;
-    <label for='panalytical_omnia_axios_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='panalytical_omnia_axios_format'>Format</label>&nbsp;
     <select name="panalytical_omnia_axios_format" id="panalytical_omnia_axios_format">
         <option value='csv'>CSV</option>
         <option value='csv_multi'>CSV (multi)</option>
@@ -13,7 +13,7 @@
     <table cellpadding="0" cellspacing="0">
  <!--
         <tr>
-            <td><label for="panalytical_axios_xrf_sample">Sample search</label></td>
+            <td><label i18n:translate="" for="panalytical_axios_xrf_sample">Sample search</label></td>
             <td>
                 <select name="panalytical_axios_xrf_sample" id="panalytical_axios_xrf_sample">
                     <option value="requestid">Analysis Request ID</option>
@@ -26,7 +26,7 @@
   -->
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="panalytical_omnia_axios_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="panalytical_omnia_axios_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="panalytical_omnia_axios_artoapply" id="panalytical_omnia_axios_artoapply">
                     <option value="received">Received</option>
@@ -35,7 +35,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="panalytical_omnia_axios_file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="panalytical_omnia_axios_file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="panalytical_omnia_axios_override" id="panalytical_omnia_axios_file_override">
                     <option value="nooverride">Don't override results</option>
@@ -46,18 +46,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="panalytical_omnia_axios_instrument" id="panalytical_omnia_axios_fileinstrument"

--- a/bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf_import.pt
+++ b/bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf_import.pt
@@ -24,9 +24,10 @@
             </td>
         </tr>
   -->
+    <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="panalytical_omnia_axios_artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="panalytical_omnia_axios_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="panalytical_omnia_axios_artoapply" id="panalytical_omnia_axios_artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -34,8 +35,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="panalytical_omnia_axios_file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="panalytical_omnia_axios_file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="panalytical_omnia_axios_override" id="panalytical_omnia_axios_file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -44,15 +45,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="panalytical_omnia_axios_instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="panalytical_omnia_axios_instrument" id="panalytical_omnia_axios_fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/rigaku/supermini/wxrf_import.pt
+++ b/bika/lims/exportimport/instruments/rigaku/supermini/wxrf_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/rigaku/supermini/wxrf_import.pt
+++ b/bika/lims/exportimport/instruments/rigaku/supermini/wxrf_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='data_file'>File</label>&nbsp;
+    <label i18n:translate="" for='data_file'>File</label>&nbsp;
     <input type="file" name="data_file" id="data_file"/>
     &nbsp;&nbsp;
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"

--- a/bika/lims/exportimport/instruments/rochecobas/taqman/model48_import.pt
+++ b/bika/lims/exportimport/instruments/rochecobas/taqman/model48_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="rochecobas_taqman_model48_artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="rochecobas_taqman_model48_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="rochecobas_taqman_model48_artoapply" id="rochecobas_taqman_model48_artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="rochecobas_taqman_model48_file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="rochecobas_taqman_model48_file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="rochecobas_taqman_model48_override" id="rochecobas_taqman_model48_file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="rochecobas_taqman_model48_instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="rochecobas_taqman_model48_instrument" id="rochecobas_taqman_model48_fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/rochecobas/taqman/model48_import.pt
+++ b/bika/lims/exportimport/instruments/rochecobas/taqman/model48_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='rochecobas_taqman_model48_file'>File</label>&nbsp;
+    <label i18n:translate="" for='rochecobas_taqman_model48_file'>File</label>&nbsp;
     <input type="file" name="rochecobas_taqman_model48_file" id="rochecobas_taqman_model48_file"/>
     &nbsp;&nbsp;
-    <label for='rochecobas_taqman_model48_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='rochecobas_taqman_model48_format'>Format</label>&nbsp;
     <select name="rochecobas_taqman_model48_format" id="rochecobas_taqman_model48_format">
         <option value='rsf'>RFS</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="rochecobas_taqman_model48_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="rochecobas_taqman_model48_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="rochecobas_taqman_model48_artoapply" id="rochecobas_taqman_model48_artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="rochecobas_taqman_model48_file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="rochecobas_taqman_model48_file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="rochecobas_taqman_model48_override" id="rochecobas_taqman_model48_file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="rochecobas_taqman_model48_instrument" id="rochecobas_taqman_model48_fileinstrument"

--- a/bika/lims/exportimport/instruments/rochecobas/taqman/model96_import.pt
+++ b/bika/lims/exportimport/instruments/rochecobas/taqman/model96_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="rochecobas_taqman_model96_artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="rochecobas_taqman_model96_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="rochecobas_taqman_model96_artoapply" id="rochecobas_taqman_model96_artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="rochecobas_taqman_model96_file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="rochecobas_taqman_model96_file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="rochecobas_taqman_model96_override" id="rochecobas_taqman_model96_file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="rochecobas_taqman_model96_instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="rochecobas_taqman_model96_instrument" id="rochecobas_taqman_model96_fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/rochecobas/taqman/model96_import.pt
+++ b/bika/lims/exportimport/instruments/rochecobas/taqman/model96_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='rochecobas_taqman_model96_file'>File</label>&nbsp;
+    <label i18n:translate="" for='rochecobas_taqman_model96_file'>File</label>&nbsp;
     <input type="file" name="rochecobas_taqman_model96_file" id="rochecobas_taqman_model96_file"/>
     &nbsp;&nbsp;
-    <label for='rochecobas_taqman_model96_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='rochecobas_taqman_model96_format'>Format</label>&nbsp;
     <select name="rochecobas_taqman_model96_format" id="rochecobas_taqman_model96_format">
         <option value='rsf'>RFS</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="rochecobas_taqman_model96_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="rochecobas_taqman_model96_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="rochecobas_taqman_model96_artoapply" id="rochecobas_taqman_model96_artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="rochecobas_taqman_model96_file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="rochecobas_taqman_model96_file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="rochecobas_taqman_model96_override" id="rochecobas_taqman_model96_file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="rochecobas_taqman_model96_instrument" id="rochecobas_taqman_model96_fileinstrument"

--- a/bika/lims/exportimport/instruments/scilvet/abc/plus_import.pt
+++ b/bika/lims/exportimport/instruments/scilvet/abc/plus_import.pt
@@ -11,8 +11,8 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
-            <td>
+            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
                     <option value="received_tobeverified">Received and to be verified</option>
@@ -20,8 +20,8 @@
             </td>
         </tr>
         <tr>
-            <td><label for="file_override">Results override</label></td>
-            <td>
+            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
                     <option value="override">Override non-empty results</option>
@@ -30,15 +30,20 @@
             </td>
         </tr>
         <tr>
+            <td colspan=2>
+              <label for="title">Instrument Calibration Import</label>
+            </td>
+        </tr>
+        <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
-            <td>
-                <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
-                    If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),
-                    it will use the record's identifier to find matches with Reference Sample IDs.
-                    If a Reference Sample ID is found, the system will automatically create a
-                    Calibration Test (Reference Analysis) and will link it to the instrument selected below.<br/>
-                    If no instrument selected, no Calibration Test will be created for orphan IDs.
+            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-padding-top">
+                <p i18n:translate="" class="instrument-import-paragraph">
+                    If an imported result does not match Analysis Requests, Samples,
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    When a matching Reference Sample ID is found, the system automatically creates
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"
                         tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/scilvet/abc/plus_import.pt
+++ b/bika/lims/exportimport/instruments/scilvet/abc/plus_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='data_file'>File</label>&nbsp;
+    <label i18n:translate="" for='data_file'>File</label>&nbsp;
     <input type="file" name="data_file" id="data_file"/>
     &nbsp;&nbsp;
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td class="instrument-import"><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td class="instrument-import"><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td class="instrument-import">
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td class="instrument-import"><label for="file_override">Results override</label></td>
+            <td class="instrument-import"><label i18n:translate="" for="file_override">Results override</label></td>
             <td class="instrument-import">
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,18 +31,18 @@
         </tr>
         <tr>
             <td colspan=2>
-              <label for="title">Instrument Calibration Import</label>
+              <label i18n:translate="" for="title">Instrument Calibration Import</label>
             </td>
         </tr>
         <tr class="instrument-import-border-top">
             <!-- Instrument selector. For calibration tests -->
-            <td class="instrument-import-selector"><label for="instrument">Instrument</label></td>
+            <td class="instrument-import-selector"><label i18n:translate="" for="instrument">Instrument</label></td>
             <td class="instrument-import-padding-top">
                 <p i18n:translate="" class="instrument-import-paragraph">
                     If an imported result does not match Analysis Requests, Samples,
-                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.<br>
+                    Reference Analyses or Duplicates, the result's identifier is matched Reference Sample IDs.
                     When a matching Reference Sample ID is found, the system automatically creates
-                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.<br>
+                    a Reference Analysis as Calibration test, and will link it to the instrument selected below.
                     If no instrument is selected, no Calibration tests will be created for orphan IDs.
                 </p>
                 <select name="instrument" id="fileinstrument"

--- a/bika/lims/exportimport/instruments/sealanalytical/aq2/aq2_import.pt
+++ b/bika/lims/exportimport/instruments/sealanalytical/aq2/aq2_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='data_file'>File</label>&nbsp;
+    <label i18n:translate="" for='data_file'>File</label>&nbsp;
     <input type="file" name="data_file" id="data_file"/>
     &nbsp;&nbsp;
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -11,7 +11,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td>
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -20,7 +20,7 @@
             </td>
         </tr>
         <tr>
-            <td><label for="file_override">Results override</label></td>
+            <td><label i18n:translate="" for="file_override">Results override</label></td>
             <td>
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
@@ -31,7 +31,7 @@
         </tr>
         <tr>
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
+            <td style='vertical-align:top;padding-right:30px;'><label i18n:translate="" for="instrument">Instrument</label></td>
             <td>
                 <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
                     If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),

--- a/bika/lims/exportimport/instruments/sysmex/xs/i1000_import.pt
+++ b/bika/lims/exportimport/instruments/sysmex/xs/i1000_import.pt
@@ -1,7 +1,7 @@
     <p></p>
 
     <!-- Analysis service to apply the results -->
-    <label for='analysis_service'>Analysis Service</label>
+    <label i18n:translate="" for='analysis_service'>Analysis Service</label>
     <select name="analysis_service" id="analysis_service" tal:define="analysislist view/getAnalysisServicesDisplayList">
         <tal:options repeat="option analysislist">
         <option tal:attributes="value python:option;"
@@ -15,17 +15,17 @@
     </p>
     <!-- If analysis service is selected we have to specify the Default Result Key -->
     <div name="default_result" style='display:none'>
-        <label for='default_result'>Default Result Key</label>
+        <label i18n:translate="" for='default_result'>Default Result Key</label>
         <input type="text" name="default_result" id="default_result">
         Please, introduce the result key column to use as a default result.
     </div>
     <p></p>
     <!-- File importer -->
-    <label for=''>File</label>&nbsp;
+    <label i18n:translate="" for=''>File</label>&nbsp;
     <input type="file" name="sysmex_xs_1000i_file" id="sysmex_xs_1000i_file"/>
     &nbsp;&nbsp;
     <!-- File format selector -->
-    <label for='sysmex_xs_1000i_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='sysmex_xs_1000i_format'>Format</label>&nbsp;
     <select name="sysmex_xs_1000i_format" id="sysmex_xs_1000i_format">
         <option value='csv'>CSV</option>
     </select>
@@ -34,7 +34,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="sysmex_xs_1000i_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td><label i18n:translate="" for="sysmex_xs_1000i_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td>
                 <select name="sysmex_xs_1000i_artoapply" id="sysmex_xs_1000i_artoapply">
                     <option value="received">Received</option>
@@ -43,7 +43,7 @@
             </td>
         </tr>
         <tr>
-            <td><label for="sysmex_xs_1000i_file_override">Results override</label></td>
+            <td><label i18n:translate="" for="sysmex_xs_1000i_file_override">Results override</label></td>
             <td>
                 <select name="sysmex_xs_1000i_override" id="sysmex_xs_1000i_file_override">
                     <option value="nooverride">Don't override results</option>
@@ -54,7 +54,7 @@
         </tr>
         <tr>
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="sysmex_xs_1000i_instrument">Instrument</label></td>
+            <td style='vertical-align:top;padding-right:30px;'><label i18n:translate="" for="sysmex_xs_1000i_instrument">Instrument</label></td>
             <td>
                 <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
                     If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),

--- a/bika/lims/exportimport/instruments/sysmex/xs/i500_import.pt
+++ b/bika/lims/exportimport/instruments/sysmex/xs/i500_import.pt
@@ -1,7 +1,7 @@
     <p></p>
 
     <!-- Analysis service to apply the results -->
-    <label for='analysis_service'>Analysis Service</label>
+    <label i18n:translate="" for='analysis_service'>Analysis Service</label>
     <select name="analysis_service" id="analysis_service" tal:define="analysislist view/getAnalysisServicesDisplayList">
         <tal:options repeat="option analysislist">
         <option tal:attributes="value python:option;"
@@ -15,17 +15,17 @@
     </p>
     <!-- If analysis service is selected we have to specify the Default Result Key -->
     <div name="default_result" style='display:none'>
-        <label for='default_result'>Default Result Key</label>
+        <label i18n:translate="" for='default_result'>Default Result Key</label>
         <input type="text" name="default_result" id="default_result">
         Please, introduce the result key column to use as a default result.
     </div>
     <p></p>
     <!-- File importer -->
-    <label for=''>File</label>&nbsp;
+    <label i18n:translate="" for=''>File</label>&nbsp;
     <input type="file" name="sysmex_xs_500i_file" id="sysmex_xs_500i_file"/>
     &nbsp;&nbsp;
     <!-- File format selector -->
-    <label for='sysmex_xs_500i_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='sysmex_xs_500i_format'>Format</label>&nbsp;
     <select name="sysmex_xs_500i_format" id="sysmex_xs_500i_format">
         <option value='csv'>CSV</option>
     </select>
@@ -34,7 +34,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="sysmex_xs_500i_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td><label i18n:translate="" for="sysmex_xs_500i_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td>
                 <select name="sysmex_xs_500i_artoapply" id="sysmex_xs_500i_artoapply">
                     <option value="received">Received</option>
@@ -43,7 +43,7 @@
             </td>
         </tr>
         <tr>
-            <td><label for="sysmex_xs_500i_file_override">Results override</label></td>
+            <td><label i18n:translate="" for="sysmex_xs_500i_file_override">Results override</label></td>
             <td>
                 <select name="sysmex_xs_500i_override" id="sysmex_xs_500i_file_override">
                     <option value="nooverride">Don't override results</option>
@@ -54,7 +54,7 @@
         </tr>
         <tr>
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="sysmex_xs_500i_instrument">Instrument</label></td>
+            <td style='vertical-align:top;padding-right:30px;'><label i18n:translate="" for="sysmex_xs_500i_instrument">Instrument</label></td>
             <td>
                 <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
                     If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),

--- a/bika/lims/exportimport/instruments/tescan/tima/tima_import.pt
+++ b/bika/lims/exportimport/instruments/tescan/tima/tima_import.pt
@@ -1,12 +1,12 @@
     <p></p>
 
     <!-- Input file selector -->
-    <label for='filename'>File</label>&nbsp;
+    <label i18n:translate="" for='filename'>File</label>&nbsp;
     <input type="file" name="filename" id="filename"/>
     &nbsp;&nbsp;
 
     <!-- Format file selector -->
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -17,7 +17,7 @@
         <tr>
 
             <!-- Allowed states of the analysis requests to look for -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td style='vertical-align:top;padding-right:30px;'><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td>
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -28,7 +28,7 @@
         <tr>
 
             <!-- Results overriding -->
-            <td><label for="override">Results override</label></td>
+            <td><label i18n:translate="" for="override">Results override</label></td>
             <td>
                 <select name="override" id="override">
                     <option value="nooverride">Don't override results</option>
@@ -39,7 +39,7 @@
         </tr>
         <tr>
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
+            <td style='vertical-align:top;padding-right:30px;'><label i18n:translate="" for="instrument">Instrument</label></td>
             <td>
                 <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
                     If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),

--- a/bika/lims/exportimport/instruments/thermoscientific/arena/xt20_import.pt
+++ b/bika/lims/exportimport/instruments/thermoscientific/arena/xt20_import.pt
@@ -1,9 +1,9 @@
 <p></p>
 
-<label for='thermoscientific_arena_20XT_file'>File</label>&nbsp;
+<label i18n:translate="" for='thermoscientific_arena_20XT_file'>File</label>&nbsp;
 <input type="file" name="thermoscientific_arena_20XT_file" id="thermoscientific_arena_20XT_file"/>
 &nbsp;&nbsp;
-<label for='thermoscientific_arena_20XT_format'>Format</label>&nbsp;
+<label i18n:translate="" for='thermoscientific_arena_20XT_format'>Format</label>&nbsp;
 <select name="thermoscientific_arena_20XT_format" id="thermoscientific_arena_20XT_format">
     <option value='rpr.csv'>CSV (RPR)</option>
 </select>
@@ -11,7 +11,7 @@
 <h3>Advanced options</h3>
 <table cellpadding="0" cellspacing="0">
     <tr>
-        <td><label for="thermoscientific_arena_20XT_artoapply">Analysis Requests state</label>&nbsp;</td>
+        <td><label i18n:translate="" for="thermoscientific_arena_20XT_artoapply">Analysis Requests state</label>&nbsp;</td>
         <td>
             <select name="thermoscientific_arena_20XT_artoapply" id="thermoscientific_arena_20XT_artoapply">
                 <option value="received">Received</option>
@@ -20,7 +20,7 @@
         </td>
     </tr>
     <tr>
-        <td><label for="thermoscientific_arena_20XT_override">Results override</label></td>
+        <td><label i18n:translate="" for="thermoscientific_arena_20XT_override">Results override</label></td>
         <td>
             <select name="thermoscientific_arena_20XT_override" id="thermoscientific_arena_20XT_override">
                 <option value="nooverride">Don't override results</option>
@@ -30,7 +30,7 @@
         </td>
     </tr>
     <tr>
-        <td style='vertical-align:top;padding-right:30px;'><label for="thermoscientific_arena_20XT_instrument">Instrument</label></td>
+        <td style='vertical-align:top;padding-right:30px;'><label i18n:translate="" for="thermoscientific_arena_20XT_instrument">Instrument</label></td>
         <td>
             <select name="thermoscientific_arena_20XT_instrument" id="thermoscientific_arena_20XT_instrument"
                     tal:define="instrlist view/getInstruments">

--- a/bika/lims/exportimport/instruments/thermoscientific/gallery/Ts9861x_import.pt
+++ b/bika/lims/exportimport/instruments/thermoscientific/gallery/Ts9861x_import.pt
@@ -1,9 +1,9 @@
     <p></p>
 
-    <label for='thermoscientific_gallery_9861x_file'>File</label>&nbsp;
+    <label i18n:translate="" for='thermoscientific_gallery_9861x_file'>File</label>&nbsp;
     <input type="file" name="thermoscientific_gallery_9861x_file" id="thermoscientific_gallery_9861x_file"/>
     &nbsp;&nbsp;
-    <label for='thermoscientific_gallery_9861x_format'>Format</label>&nbsp;
+    <label i18n:translate="" for='thermoscientific_gallery_9861x_format'>Format</label>&nbsp;
     <select name="thermoscientific_gallery_9861x_format" id="thermoscientific_gallery_9861x_format">
         <option value='tsv_40'>TSV/XLS v4.0</option>
     </select>
@@ -12,7 +12,7 @@
     <table cellpadding="0" cellspacing="0">
  <!--
         <tr>
-            <td><label for="thermoscientific_gallery_9861x_sample">Sample search</label></td>
+            <td><label i18n:translate="" for="thermoscientific_gallery_9861x_sample">Sample search</label></td>
             <td>
                 <select name="thermoscientific_gallery_9861x_sample" id="thermoscientific_gallery_9861x_sample">
                     <option value="requestid">Analysis Request ID</option>
@@ -24,7 +24,7 @@
         </tr>
   -->
         <tr>
-            <td><label for="thermoscientific_gallery_9861x_artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td><label i18n:translate="" for="thermoscientific_gallery_9861x_artoapply">Analysis Requests state</label>&nbsp;</td>
             <td>
                 <select name="thermoscientific_gallery_9861x_artoapply" id="thermoscientific_gallery_9861x_artoapply">
                     <option value="received">Received</option>
@@ -33,7 +33,7 @@
             </td>
         </tr>
         <tr>
-            <td><label for="thermoscientific_gallery_9861x_override">Results override</label></td>
+            <td><label i18n:translate="" for="thermoscientific_gallery_9861x_override">Results override</label></td>
             <td>
                 <select name="thermoscientific_gallery_9861x_override" id="thermoscientific_gallery_9861x_override">
                     <option value="nooverride">Don't override results</option>
@@ -44,7 +44,7 @@
         </tr>
         <tr>
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="thermoscientific_gallery_9861x_instrument">Instrument</label></td>
+            <td style='vertical-align:top;padding-right:30px;'><label i18n:translate="" for="thermoscientific_gallery_9861x_instrument">Instrument</label></td>
             <td>
                 <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
                     If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),

--- a/bika/lims/exportimport/instruments/thermoscientific/multiskan/go_import.pt
+++ b/bika/lims/exportimport/instruments/thermoscientific/multiskan/go_import.pt
@@ -2,7 +2,7 @@
 
 
     <!-- Analysis service to apply the results -->
-    <label for='analysis'>Analysis Service</label>
+    <label i18n:translate="" for='analysis'>Analysis Service</label>
     <select name="analysis" id="analysis" tal:define="analysislist view/getAnalysisServicesDisplayList">
         <tal:options repeat="option analysislist">
         <option tal:attributes="value python:option;"
@@ -10,10 +10,10 @@
         </tal:options>
     </select>
     <p></p>
-    <label for='data_file'>File</label>&nbsp;
+    <label i18n:translate="" for='data_file'>File</label>&nbsp;
     <input type="file" name="data_file" id="data_file"/>
     &nbsp;&nbsp;
-    <label for='format'>Format</label>&nbsp;
+    <label i18n:translate="" for='format'>Format</label>&nbsp;
     <select name="format" id="format">
         <option value='csv'>CSV</option>
     </select>
@@ -21,7 +21,7 @@
     <h3>Advanced options</h3>
     <table cellpadding="0" cellspacing="0">
         <tr>
-            <td><label for="artoapply">Analysis Requests state</label>&nbsp;</td>
+            <td><label i18n:translate="" for="artoapply">Analysis Requests state</label>&nbsp;</td>
             <td>
                 <select name="artoapply" id="artoapply">
                     <option value="received">Received</option>
@@ -30,7 +30,7 @@
             </td>
         </tr>
         <tr>
-            <td><label for="file_override">Results override</label></td>
+            <td><label i18n:translate="" for="file_override">Results override</label></td>
             <td>
                 <select name="override" id="file_override">
                     <option value="nooverride">Don't override results</option>
@@ -41,7 +41,7 @@
         </tr>
         <tr>
             <!-- Instrument selector. For calibration tests -->
-            <td style='vertical-align:top;padding-right:30px;'><label for="instrument">Instrument</label></td>
+            <td style='vertical-align:top;padding-right:30px;'><label i18n:translate="" for="instrument">Instrument</label></td>
             <td>
                 <p i18n:translate="" style='color: #3F3F3F;font-size: 0.87em;'>
                     If the system doesn't find any match (AnalysisRequest, Sample, Reference Analysis or Duplicate),

--- a/bika/lims/profiles/default/cssregistry.xml
+++ b/bika/lims/profiles/default/cssregistry.xml
@@ -53,4 +53,10 @@
     rendering="link"
     insert-after="*"/>
 
+<stylesheet
+    id="++resource++bika.lims.css/instrument_import.css"
+    media="screen"
+    rel="stylesheet"
+    rendering="link"
+    insert-before="*"/>
 </object>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/LIMS-1833
https://github.com/bikalabs/bika.lims/issues/


## Current behavior before PR
     There was no spacing between elements
## Desired behavior after PR is merged
    Spacing between elements and added a header: Instrument Calibration Import
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
