### PR TITLE
Reverting back from changes made on branch

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -2471,14 +2471,14 @@ function AnalysisRequestAddByCol() {
                function (i, e) {
                    var arnum = $(e).parents("[arnum]").attr("arnum")
                    var fieldname = $(e).parents("[fieldname]").attr("fieldname")
-                   var value = $(e).attr("uid")
-                   if (value){
-                       state_set(arnum, fieldname, value)
-                   }
                    //var value = $(e).attr("uid")
-                   //  ? $(e).attr("uid")
-                   //  : $(e).val()
-                   //state_set(arnum, fieldname, value)
+                   //if (value){
+                   //    state_set(arnum, fieldname, value)
+                   //}
+                   var value = $(e).attr("uid")
+                     ? $(e).attr("uid")
+                     : $(e).val()
+                   state_set(arnum, fieldname, value)
                })
         // checkboxes inside ar_add_widget table.
         $.each($('[ar_add_ar_widget] input[type="checkbox"]').not('[class^="rejectionwidget-checkbox"]'),


### PR DESCRIPTION
CCContacts-not-saving-during-AR-creation

## Reverting back from branch CCContacts-not-saving-during-AR-creation regarding issue  
https://github.com/bikalabs/bika.lims/issues/1995 and I couldn't reproduce the issues reported on https://jira.bikalabs.com/browse/LIMS-2638


## Current behavior before PR
     Causes this bug https://jira.bikalabs.com/browse/LIMS-2638
## Desired behavior after PR is merged
I took out the changes that I have made previously and the contacts are still not saved
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
