### PR TITLE
LIMS-2636 Prevent inline validation in ProxyField

### DIFF
--- a/bika/lims/browser/validation.py
+++ b/bika/lims/browser/validation.py
@@ -9,7 +9,7 @@ from Products.CMFCore.utils import getToolByName
 import json
 
 
-SKIP_VALIDATION_FIELDTYPES = ('image', 'file', 'datetime', 'reference')
+SKIP_VALIDATION_FIELDTYPES = ('image', 'file', 'datetime', 'reference', 'proxy')
 
 class InlineValidationView(_IVV):
 


### PR DESCRIPTION
Inline validation on some fields falsely errors in ar-add and some other
contexts.

## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/LIMS-2636

## Current behavior before PR

When selecting sampletype (or any other proxied Sample field) in the AR-Add form, the inline validation pops up and claims that a field value is required.  This means the user needs to enter the value twice before they can continue

## Desired behavior after PR is merged

Inline validation is ignored for these fields as well as other ignored fields types.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
