### PR TITLE
Fix: Portal object has no schema/fields

### DIFF
--- a/bika/lims/jsonapi/api.py
+++ b/bika/lims/jsonapi/api.py
@@ -311,6 +311,9 @@ def is_dexterity_content(brain_or_object):
 def get_field(brain_or_object, name, default=None):
     """Return the named field
     """
+    # Portal has no schema
+    if is_root(brain_or_object):
+        return None
     fields = api.get_fields(brain_or_object)
     return fields.get(name, default)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixed missing schema when trying to retrieve a field of the portal object

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
