### PR TITLE
Issue-2010: Fixed 'Show More' Button disappearance after first click

### DIFF
--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -41,7 +41,7 @@ function BikaListingTableView() {
 			var limit_from = parseInt($(this).attr('data-limitfrom'));
 			url = url.replace('_limit_from=','_olf=');
 			url += '&'+formid+"_limit_from="+limit_from;
-			$('#'+formid+' a.bika_listing_show_more').fadeOut();
+			// $('#'+formid+' a.bika_listing_show_more').fadeOut();
 			var tbody = $('table.bika-listing-table[form_id="'+formid+'"] tbody.item-listing-tbody');
 			// The results must be filtered?
 			var filter_options = [];
@@ -76,8 +76,8 @@ function BikaListingTableView() {
     			}).always(function() {
 					var numitems = $('table.bika-listing-table[form_id="'+formid+'"] tbody.item-listing-tbody tr').length;
 					$('#'+formid+' span.number-items').html(numitems);
-					if (numitems % pagesize == 0) {
-						$('#'+formid+' a.bika_listing_show_more').show();
+					if (numitems % pagesize != 0) {
+						$('#'+formid+' a.bika_listing_show_more').hide();
 					}
 				});
 		});

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+Issue-2010: Bika Listing Table: "Show More" button disappears
 Issue-2012: AR Template Analysis don't get applied if an Analysis Profile is selected
 Issue-2015: Copy AS functionality from the "bika_analysisservices" view raises an error
 Issue-1974: Clicking on the "Arrow Button" of an empty cell in the AR Add View causes a JS Error and endless Spinner


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Inverted logic, so that it is not needed to use the JQuery fadeout()
Methods, as it seems that it causes race condition if the request
returns while the button is still fading out.

Please see https://github.com/bikalabs/bika.lims/issues/2010 for more details

## Current behavior before PR

"Show More" Button disappears after first click.

## Desired behavior after PR is merged

"Show More" Button re-appears until the last batch of items is rendered.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
