### PR TITLE
Bugfix/issue 2062 worksheet error on add duplicate

### DIFF
--- a/bika/lims/browser/worksheet/templates/add_duplicate.pt
+++ b/bika/lims/browser/worksheet/templates/add_duplicate.pt
@@ -1,55 +1,53 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:tal="http://xml.zope.org/namespaces/tal"
-	xmlns:metal="http://xml.zope.org/namespaces/metal"
-	xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-	metal:use-macro="here/main_template/macros/master"
-	i18n:domain="bika">
-<body>
+             xmlns:tal="http://xml.zope.org/namespaces/tal"
+             xmlns:metal="http://xml.zope.org/namespaces/metal"
+             xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+             metal:use-macro="here/main_template/macros/master"
+             i18n:domain="bika">
+  <body>
 
-<metal:content-title fill-slot="content-title">
-	<h1>
+    <metal:content-title fill-slot="content-title">
+      <h1>
         <img tal:condition="view/icon | nothing"
-            src="" tal:attributes="src view/icon"/>
+             src="" tal:attributes="src view/icon"/>
         <img tal:condition="view/getPriorityIcon | nothing"
              src="" tal:attributes="src view/getPriorityIcon"/>
         <span class="documentFirstHeading" tal:content="view/title"/>
-    </h1>
-</metal:content-title>
+      </h1>
+    </metal:content-title>
 
-<metal:content-description fill-slot="content-description">
-	<div class="documentDescription"
-		tal:content="view/description"
-		tal:condition="view/description"/>
-</metal:content-description>
+    <metal:content-description fill-slot="content-description">
+      <div class="documentDescription"
+                  tal:content="view/description"
+                  tal:condition="view/description"/>
+    </metal:content-description>
 
-<metal:content-core fill-slot="content-core">
-	<fieldset tal:define="portal context/@@plone_portal_state/portal;">
+    <metal:content-core fill-slot="content-core">
 
-		<tal:comment replace="nothing">
-		The position dropdown's value is not part of the bika_listing form.
-		The value is inserted into form values by worksheet.js
-		</tal:comment>
-		<div style="margin-bottom:1em">
-			<span tal:content="string:Insert into worksheet at position: " i18n:translate=""/>
-			<select id="position">
-				<tal:options repeat="position view/getAvailablePositions">
-					<option tal:attributes="value position" tal:content="position"/>
-				</tal:options>
-				<option value="new" i18n:translate="">New</option>
-			</select>
-		</div>
-		<span id="worksheet_add_duplicate_ars" tal:content="structure view/ARs/contents_table"/>
+      <fieldset tal:define="portal context/@@plone_portal_state/portal;">
+        <tal:comment replace="nothing">
+          The position dropdown's value is not part of the bika_listing form.
+          The value is inserted into form values by worksheet.js
+        </tal:comment>
+        <div style="margin-bottom:1em">
+          <span tal:content="string:Insert into worksheet at position: " i18n:translate=""/>
+          <select id="position">
+            <tal:options repeat="position view/getAvailablePositions">
+              <option tal:attributes="value position" tal:content="position"/>
+            </tal:options>
+            <option value="new" i18n:translate="">New</option>
+          </select>
+        </div>
+        <span id="worksheet_add_duplicate_ars" tal:content="structure view/ARs/contents_table"/>
+      </fieldset>
 
-	</fieldset>
+      <tal:remarks define="field python:context.Schema()['Remarks'];
+                           errors python:{};">
+        <p style="margin-top:2em;"/>
+        <metal:widget use-macro="python:context.widget('Remarks', mode='edit')" />
+      </tal:remarks>
 
-	<tal:remarks define="
-		field python:context.Schema()['Remarks'];
-		errors python:{};">
-		<p style="margin-top:2em;"/>
-		 <metal:widget use-macro="python:context.widget('Remarks', mode='edit')" />
-	</tal:remarks>
+    </metal:content-core>
 
-</metal:content-core>
-
-</body>
+  </body>
 </html>

--- a/bika/lims/browser/worksheet/views/analysisrequests.py
+++ b/bika/lims/browser/worksheet/views/analysisrequests.py
@@ -7,9 +7,7 @@
 
 from operator import itemgetter
 
-from Products.Archetypes.config import REFERENCE_CATALOG
-from Products.CMFCore.utils import getToolByName
-
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 
@@ -50,18 +48,18 @@ class AnalysisRequestsView(BikaListingView):
         ]
 
     def folderitems(self):
-        rc = getToolByName(self.context, REFERENCE_CATALOG)
         ars = {}
-
         for slot in self.context.getLayout():
             if slot['type'] != 'a':
                 continue
             ar = slot['container_uid']
             if ar not in ars:
                 ars[ar] = slot['position']
+
         items = []
         for ar, pos in ars.items():
-            ar = rc.lookupObject(ar)
+            pos = str(pos)
+            ar = api.get_object_by_uid(ar)
             # this folderitems doesn't subclass from the bika_listing.py
             # so we create items from scratch
             item = {

--- a/bika/lims/browser/worksheet/views/analysisrequests.py
+++ b/bika/lims/browser/worksheet/views/analysisrequests.py
@@ -6,23 +6,24 @@
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 from operator import itemgetter
+
 from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.i18nl10n import ulocalized_time
 
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 
 
 class AnalysisRequestsView(BikaListingView):
-    ## This table displays a list of ARs referenced by this worksheet.
-    ## used in add_duplicate view.
+    """This table displays a list of ARs referenced by this worksheet.
+    Used in add_duplicate view.
+    """
     def __init__(self, context, request):
         BikaListingView.__init__(self, context, request)
         self.context_actions = {}
         self.catalog = 'bika_analysis_catalog'
         self.contentFilter = {'portal_type': 'Analysis',
-                              'review_state':'impossible_state'}
+                              'review_state': 'impossible_state'}
         self.base_url = self.context.absolute_url()
         self.view_url = self.context.absolute_url() + "/add_duplicate"
         self.show_sort_column = False
@@ -37,23 +38,26 @@ class AnalysisRequestsView(BikaListingView):
             'Client': {'title': _('Client')},
             'created': {'title': _('Date Requested')},
         }
+
         self.review_states = [
-            {'id':'default',
-             'title': _('All'),
-             'contentFilter':{},
-             'transitions': [],
-             'columns':['Position', 'RequestID', 'Client', 'created'],
+            {
+                'id': 'default',
+                'title': _('All'),
+                'contentFilter': {},
+                'transitions': [],
+                'columns':['Position', 'RequestID', 'Client', 'created'],
             },
         ]
 
     def folderitems(self):
         rc = getToolByName(self.context, REFERENCE_CATALOG)
         ars = {}
+
         for slot in self.context.getLayout():
             if slot['type'] != 'a':
                 continue
             ar = slot['container_uid']
-            if not ars.has_key(ar):
+            if ar not in ars:
                 ars[ar] = slot['position']
         items = []
         for ar, pos in ars.items():
@@ -76,13 +80,13 @@ class AnalysisRequestsView(BikaListingView):
                 'replace': {},
                 'before': {},
                 'after': {},
-                'choices':{},
+                'choices': {},
                 'class': {},
                 'state_class': 'state-active',
                 'allow_edit': [],
                 'required': [],
             }
             items.append(item)
-        items = sorted(items, key = itemgetter('Position'))
+        items = sorted(items, key=itemgetter('Position'))
 
         return items

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1b3 (unreleased)
 --------------------
 
+- Issue-2062: Worksheet raises Error on `add_duplicate` view
 - Issue-2011: Client Folder Listing Table decreases Bika LIMS performance and is unusable for many Clients
 - Issue-2068: Member Discount is always applied on adding new ARs
 - Issue-2052: Computed Sample Field "SampleTypeUID" does not check if a SampleType is set


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalabs/bika.lims/issues/2062 for further details and screenshots

## Current behavior before PR

Worksheet 'Add Duplicate' view raises an error

## Desired behavior after PR is merged

Worksheet ' Add Duplicate' view is back working

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
