### PR TITLE
Fixed multiple partition creation from ARTemple

### DIFF
--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -129,7 +129,8 @@ def create_analysisrequest(context, request, values, analyses=None,
     if not secondary:
         # Create sample partitions
         if not partitions:
-            partitions = [{'services': service_uids}]
+            partitions = values.get('Partitions',
+                            [{'services': service_uids}])
         for n, partition in enumerate(partitions):
             # Calculate partition id
             partition_prefix = sample.getId() + "-P"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/BC-58

## Current behavior before PR
When an AR is created with an ARTemplate with multiple partitions, only one sample partition is created.

## Desired behavior after PR is merged
When an AR is created with an ARTemplate with multiple partitions, multiple sample partitions are created.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
