### PR TITLE
Handle the case where cookie on request is None on IE

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -740,12 +740,16 @@ class BikaListingView(BrowserView):
             msg = "category_index must be defined when using ajax_categories."
             raise AssertionError(msg)
         # Getting the bika_listing_filter_bar cookie
-        cookie_filter_bar = self.request.get('bika_listing_filter_bar', '')
+        cookie_value = self.request.get('bika_listing_filter_bar', '')
         self.request.response.setCookie(
             'bika_listing_filter_bar', None, path='/', max_age=0)
         # Saving the filter bar values
-        cookie_filter_bar = json.loads(cookie_filter_bar) if\
-            cookie_filter_bar else ''
+        cookie_filter_bar = ''
+        try:
+            cookie_filter_bar = json.loads(cookie_value)
+        except ValueError, e:
+            logger.error('%s: cookie value %s' % (str(e), cookie_value))
+
         # Creating a dict from cookie data
         cookie_data = {}
         for k, v in cookie_filter_bar:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
On IE bika_listing fails when stack is nginx, haproxy, plone. The cookie value is [None] and the code doesn't handle that, This PR traps the ValueError and allow the function to continue as if cookie data was empty. The display column config work as they do in chrome or ff. Note that this issue does no occur if Varnish is in the stack BUT the display column config has no affect which is https://jira.bikalabs.com/browse/BC-42

## Current behavior before PR
If haproxy and no varnish, bika_listing crashes on IE.

## Desired behavior after PR is merged
If haproxy and no varnish, bika_listing does not crash on IE.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
