### PR TITLE
Issue-2065: Sort order in Bika Setup Listings

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -830,7 +830,7 @@ class BikaListingView(BrowserView):
         >>> browser.open(portal_url+"/bika_setup/bika_sampletypes/folder_view?",
         ... "list_pagesize=10&list_review_state=default")
         >>> browser.contents
-        '...Water...'
+        '...Apple Pulp...'
         """
 
         # self.contentsMethod = self.context.getFolderContents

--- a/bika/lims/content/analysiscategory.py
+++ b/bika/lims/content/analysiscategory.py
@@ -26,7 +26,7 @@ import transaction
 @indexer(IAnalysisCategory)
 def sortable_title_with_sort_key(instance):
     sort_key = instance.getSortKey()
-    if sort_key:
+    if sort_key is not None:
         return "{:010.3f}{}".format(sort_key, instance.Title())
     return instance.Title()
 

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -156,6 +156,7 @@ class AnalysisServicesView(BikaListingView):
         self.show_select_column = True
         self.show_select_all_checkbox = False
         self.pagesize = 25
+        self.sort_on = "sortable_title"
 
         self.categories = []
         self.do_cats = self.context.bika_setup.getCategoriseAnalysisServices()

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -318,12 +318,6 @@ class AnalysisServicesView(BikaListingView):
             for i in range(len(self.review_states)):
                 self.review_states[i]['columns'].remove('Price')
 
-        bsc = getToolByName(self.context, 'bika_setup_catalog')
-        self.an_cats = bsc(portal_type="AnalysisCategory",
-                           sort_on="sortable_title")
-        self.an_cats_order = dict([(b.Title, "{:04}".format(a))
-                                  for a, b in enumerate(self.an_cats)])
-
     def isItemAllowed(self, obj):
         """
         It checks if the item can be added to the list depending on the
@@ -414,6 +408,12 @@ class AnalysisServicesView(BikaListingView):
         return item
 
     def folderitems(self):
+        bsc = getToolByName(self.context, 'bika_setup_catalog')
+        self.an_cats = bsc(portal_type="AnalysisCategory",
+                           sort_on="sortable_title")
+        self.an_cats_order = dict([(b.Title, "{:04}".format(a))
+                                  for a, b in enumerate(self.an_cats)])
+
         items = super(AnalysisServicesView, self).folderitems()
         if self.do_cats:
             self.categories = map(lambda x: x[0],

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1b3 (unreleased)
 --------------------
 
+- Issue-2065: Sort order on all landing pages are broken
 - Issue-2081: Fixed multiple partition creation from ARTemple
 - Issue-2089: Bika Listing display columns uses localized column headers in Cookie
 - Issue-2063: Batch Book raises an Error if the Batch inherits from 2 ARs


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalabs/bika.lims/issues/2065 for further details and screenshots

## Current behavior before PR

- Listings in Bika Setup were not listed alphabetically per default
- Custom sort key for analysis categories did not work for the value `0.0`
- Sort on `sortable_title` did not work

## Desired behavior after PR is merged

- Sort order in Bika Listings sort alphabetically per default
- Custom sort key for analysis categories work as described in the help text
- It is possible now to sort on `sortable_title`

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
