### PR TITLE
Issue-2095: Declare getAccreditationBodyLogo public

### DIFF
--- a/bika/lims/content/laboratory.py
+++ b/bika/lims/content/laboratory.py
@@ -116,6 +116,11 @@ class Laboratory(UniqueObject, Organisation):
     displayContentsTab = False
     schema = schema
 
+    # needed to access the field for the front-page Portlet for Anonymous, w/o
+    # making the whole Laboratory viewable by Anonymous.
+    # Only the permission "Access contents information" is needed
+    security.declarePublic('getAccreditationBodyLogo')
+
     security.declareProtected(View, 'getSchema')
     def getSchema(self):
         return self.schema

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1b3 (unreleased)
 --------------------
 
+- Issue-2095: Permission of getAccreditationBodyLogo
 - Issue-2065: Sort order on all landing pages are broken
 - Issue-2081: Fixed multiple partition creation from ARTemple
 - Issue-2089: Bika Listing display columns uses localized column headers in Cookie


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalabs/bika.lims/issues/2095 for details and screenshots

## Current behavior before PR

Portlet renders an error message if the accreditation logo could not be accessed.

## Desired behavior after PR is merged

Porlet does not render if the accreditation logo could not be obtained.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
