### PR TITLE
Cleaned up cookie value check in BikaListingView

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -746,10 +746,15 @@ class BikaListingView(BrowserView):
             'bika_listing_filter_bar', None, path='/', max_age=0)
         # Saving the filter bar values
         cookie_filter_bar = ''
-        try:
-            cookie_filter_bar = json.loads(cookie_value)
-        except ValueError, e:
-            logger.error('%s: cookie value %s' % (str(e), cookie_value))
+        if cookie_value is not None and \
+           cookie_value not in ([], '', [None]): #There maybe more
+            try:
+                cookie_filter_bar = json.loads(cookie_value)
+            except ValueError, e:
+                logger.error(
+                    'BikaListingView: cannot parse cookie value %s (%s)' % (
+                        str(e), cookie_value))
+
 
         # Creating a dict from cookie data
         cookie_data = {}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

## Current behavior before PR
Spurious errors in log file regarding cookie problems

## Desired behavior after PR is merged
Check for valid cookie values and only show cookie value error when value is invalid.
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
