### PR TITLE
Bc 62 testing instrument

### DIFF
--- a/bika/lims/exportimport/instruments/shimadzu/icpe/multitype.py
+++ b/bika/lims/exportimport/instruments/shimadzu/icpe/multitype.py
@@ -151,7 +151,7 @@ class ICPEMultitypeCSVParser(InstrumentCSVResultsFileParser):
                     quantitation[colname] = token
 
                 val = re.sub(r"\W", "", splitted[1])
-                self._addRawResult(quantitation['Title0'],
+                self._addRawResult(quantitation['Title2'],
                                    values={val:quantitation},
                                    override=True)
             elif token:

--- a/bika/lims/exportimport/instruments/shimadzu/icpe/multitype.py
+++ b/bika/lims/exportimport/instruments/shimadzu/icpe/multitype.py
@@ -150,7 +150,7 @@ class ICPEMultitypeCSVParser(InstrumentCSVResultsFileParser):
                 else:
                     quantitation[colname] = token
 
-                val = re.sub(r"\W", "", splitted[1])
+                val = re.sub(r"\W", "", splitted[6])
                 self._addRawResult(quantitation['Title2'],
                                    values={val:quantitation},
                                    override=True)

--- a/bika/lims/tests/files/icp output.txt
+++ b/bika/lims/tests/files/icp output.txt
@@ -1,1 +1,1 @@
-1-0001	CAL1	Blank	9/23/2016 11:54:59 AM		MRC	As	QUANT	193.759	1	ppb																				After Drift Correction	-0.0936625	-0.1063610	-0.1266098								-0.1088778	0.0166172	15.26
+Metals Mix Method with IS longer cali	CAL1	1-0001	9/23/2016 11:54:59 AM		MRC	As	QUANT	193.759	1	ppb																				After Drift Correction	-0.0936625	-0.1063610	-0.1266098								-0.1088778	0.0166172	15.26

--- a/bika/lims/tests/test_InstrumentInterfaceShimadzuICPE9000Multitype.py
+++ b/bika/lims/tests/test_InstrumentInterfaceShimadzuICPE9000Multitype.py
@@ -62,7 +62,7 @@ class TestInstrumentImport(BikaSimpleTestCase):
         self.addthing(self.portal.bika_setup.bika_arpriorities, 'ARPriority',
                       title='Normal', sortKey=1)
         a = self.addthing(self.portal.bika_setup.bika_analysisservices,
-                          'AnalysisService', title='CAL1', Keyword="CAL1")
+                          'AnalysisService', title='As', Keyword="As")
         self.addthing(self.portal.bika_setup.bika_analysisprofiles,
                       'AnalysisProfile', title='MicroBio',
                       Service=[a.UID()])
@@ -82,7 +82,7 @@ Header,      File name,  Client name,  Client ID, Contact,     CC Names - Report
 Header Data, test1.csv,  Happy Hills,  HH,        Rita Mohale,                  ,                   ,                    ,                    , 10,            HHPO-001,                            ,,
 Batch Header, id,       title,     description,    ClientBatchID, ClientBatchComment, BatchLabels, ReturnSampleToClient,,,
 Batch Data,   B15-0123, New Batch, Optional descr, CC 201506,     Just a batch,                  , TRUE                ,,,
-Samples,    ClientSampleID,    SamplingDate,DateSampled,Sampler,SamplePoint,SampleMatrix,SampleType,ContainerType,ReportDryMatter,Priority,Total number of Analyses or Profiles,Price excl Tax,CAL1,,,,MicroBio,,
+Samples,    ClientSampleID,    SamplingDate,DateSampled,Sampler,SamplePoint,SampleMatrix,SampleType,ContainerType,ReportDryMatter,Priority,Total number of Analyses or Profiles,Price excl Tax,As,,,,MicroBio,,
 Analysis price,,,,,,,,,,,,,,
 "Total Analyses or Profiles",,,,,,,,,,,,,9,,,
 Total price excl Tax,,,,,,,,,,,,,,

--- a/bika/lims/tests/test_InstrumentInterfaceShimadzuICPE9000Multitype.py
+++ b/bika/lims/tests/test_InstrumentInterfaceShimadzuICPE9000Multitype.py
@@ -6,7 +6,6 @@
 from DateTime import DateTime
 from Products.CMFPlone.utils import _createObjectByType
 from bika.lims import logger
-from bika.lims.content.analysis import Analysis
 from bika.lims.exportimport.instruments.shimadzu.icpe.multitype import Import
 from bika.lims.testing import BIKA_SIMPLE_FIXTURE
 from bika.lims.tests.base import BikaSimpleTestCase


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Bug that comes from https://jira.bikalabs.com/browse/BC-7 for instrument Shimadzu ICP-AES ICPE-9000

https://jira.bikalabs.com/browse/BC-62
https://github.com/bikalabs/bika.lims/issues/


## Current behavior before PR
     Reading incorrect columns for data: Column A is AR and Column B is Analysis Service Keyword 
## Desired behavior after PR is merged
     The correct columns should be: Column C is AR and Column G is Analysis Service Keyword
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
