### PR TITLE
BC-33 Retracted Analysis should not be invoiced

### DIFF
--- a/bika/lims/browser/analysisrequest/invoice.py
+++ b/bika/lims/browser/analysisrequest/invoice.py
@@ -146,13 +146,14 @@ class InvoiceView(BrowserView):
                     # We want the analysis instead of the service, because we want the price for the client
                     # (for instance the bulk price)
                     panalysis = self._getAnalysisForProfileService(pservice.getKeyword(), analyses_from_profiles)
-                    pservices.append({
+                    if panalysis == 0:
+                        continue
+                    else:
+                        pservices.append({
                                      'title': pservice.Title(),
-                                     'price': panalysis.getPrice() if panalysis else pservice.getPrice(),
-                                     'priceVat': "%.2f" % panalysis.getVATAmount() if panalysis
-                                                                                   else pservice.getVATAmount(),
-                                     'priceTotal': "%.2f" % panalysis.getTotalPrice() if panalysis
-                                                                                   else pservice.getTotalPrice(),
+                                     'price': panalysis.getPrice(),
+                                     'priceVat': "%.2f" % panalysis.getVATAmount(),
+                                     'priceTotal': "%.2f" % panalysis.getTotalPrice(),
                                      })
                 profiles.append({'name': profile.title,
                                  'price': None,

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2010,9 +2010,10 @@ class AnalysisRequest(BaseFolder):
         # Getting all analysis request analyses
         ar_analyses = self.getAnalyses(cancellation_state='active',
                                        full_objects=True)
+        UNBILLABLE_STATES = ('not_requested', 'retracted', 'sample_received')
         for analysis in ar_analyses:
             review_state = workflow.getInfoFor(analysis, 'review_state', '')
-            if review_state not in ('not_requested', 'retracted'):
+            if review_state not in UNBILLABLE_STATES:
                 analyses.append(analysis)
         # Getting analysis request profiles
         for profile in self.getProfiles():
@@ -2062,9 +2063,10 @@ class AnalysisRequest(BaseFolder):
         # service") objects to obtain
         # the correct price later
         profile_analyses = []
+        IGNORED_STATES = ('not_requested', 'retracted', 'sample_received')
         for analysis in self.objectValues('Analysis'):
             review_state = workflow.getInfoFor(analysis, 'review_state', '')
-            if review_state != 'not_requested':
+            if review_state not in IGNORED_STATES:
                 analyses.append(analysis)
         # Getting all profiles
         analysis_profiles = self.getProfiles() if len(

--- a/bika/lims/tests/test_BC-33-retracted-analyses-shouldnot-be-invoiced.py
+++ b/bika/lims/tests/test_BC-33-retracted-analyses-shouldnot-be-invoiced.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Bika LIMS
+#
+# Copyright 2011-2017 by it's authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+
+from Products.CMFCore.WorkflowCore import WorkflowException
+from Products.CMFPlone.utils import _createObjectByType
+from Products.CMFCore.utils import getToolByName
+from bika.lims.utils import tmpID
+from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.idserver import renameAfterCreation
+from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_NAME
+from datetime import date
+from bika.lims.utils.analysisrequest import create_analysisrequest
+import unittest
+import transaction
+
+try:
+    import unittest2 as unittest
+except ImportError: # Python 2.7
+    import unittest
+
+
+class TestAnalysisRetract(BikaFunctionalTestCase):
+    layer = BIKA_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestAnalysisRetract, self).setUp()
+        login(self.portal, TEST_USER_NAME)
+
+    def test_retract_an_analysis_request_using_profile_price(self):
+        #Test the retract process to avoid LIMS-1989
+        profs = self.portal.bika_setup.bika_analysisprofiles
+        # analysisprofile-1: Trace Metals
+        analysisprofile = profs['analysisprofile-1']
+        analysisprofile.setUseAnalysisProfilePrice(True)
+        analysisprofile.setAnalysisProfilePrice('40.00')
+        catalog = getToolByName(self.portal, 'portal_catalog')
+        # Getting the first client
+        client = self.portal.clients['client-1']
+        sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+        values = {'Client': client.UID(),
+                  'Contact': client.getContacts()[0].UID(),
+                  'SamplingDate': '2015-01-01',
+                  'SampleType': sampletype.UID()}
+        # Getting some services
+        values['Profiles'] = analysisprofile.UID()
+        services = catalog(portal_type = 'AnalysisService',
+                            inactive_state = 'active')[:3]
+        service_uids = [service.getObject().UID() for service in services]
+        request = {}
+        ar = create_analysisrequest(client, request, values, service_uids)
+        transaction.commit()
+        all_analyses, all_profiles, analyses_from_profiles = ar.getServicesAndProfiles()
+        if len(all_profiles) == 0:
+            self.fail('Profiles not being used on the AR')
+        wf = getToolByName(ar, 'portal_workflow')
+        wf.doActionFor(ar, 'receive')
+
+        # Cheking if everything is going OK
+        #import pdb; pdb.set_trace()
+        self.assertEquals(ar.portal_workflow.getInfoFor(ar, 'review_state'),
+                                                        'sample_received')
+        for analysis in ar.getAnalyses(full_objects=True):
+            analysis.setResult('12')
+            wf.doActionFor(analysis, 'submit')
+            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
+                            'review_state'),'to_be_verified')
+            # retracting results
+            wf.doActionFor(analysis, 'retract')
+            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
+                            'review_state'),'retracted')
+
+        browser = self.getBrowser()
+        invoice_url = '%s/invoice' % ar.absolute_url()
+        browser.open(invoice_url)
+        if '40.00' not in browser.contents:
+            self.fail('Retracted Analyses Services found on the invoice')
+
+    def test_retract_an_analysis_request_without_profile_price(self):
+        #Test the retract process to avoid LIMS-1989
+        profs = self.portal.bika_setup.bika_analysisprofiles
+        # analysisprofile-1: Trace Metals
+        analysisprofile = profs['analysisprofile-1']
+        catalog = getToolByName(self.portal, 'portal_catalog')
+        # Getting the first client
+        client = self.portal.clients['client-1']
+        sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+        values = {'Client': client.UID(),
+                  'Contact': client.getContacts()[0].UID(),
+                  'SamplingDate': '2015-01-01',
+                  'SampleType': sampletype.UID()}
+        # Getting some services
+        values['Profiles'] = analysisprofile.UID()
+        services = catalog(portal_type = 'AnalysisService',
+                            inactive_state = 'active')[:3]
+        service_uids = [service.getObject().UID() for service in services]
+        request = {}
+        ar = create_analysisrequest(client, request, values, service_uids)
+        transaction.commit()
+        all_analyses, all_profiles, analyses_from_profiles = ar.getServicesAndProfiles()
+        if len(all_profiles) == 0:
+            self.fail('Profiles not being used on the AR')
+        wf = getToolByName(ar, 'portal_workflow')
+        wf.doActionFor(ar, 'receive')
+
+        # Cheking if everything is going OK
+        #import pdb; pdb.set_trace()
+        self.assertEquals(ar.portal_workflow.getInfoFor(ar, 'review_state'),
+                                                        'sample_received')
+        count = 0
+        for analysis in ar.getAnalyses(full_objects=True):
+            analysis.setResult('12')
+            wf.doActionFor(analysis, 'submit')
+            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
+                            'review_state'),'to_be_verified')
+            # Only retract the first one
+            if count == 0:
+                wf.doActionFor(analysis, 'retract')
+                self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
+                                'review_state'),'retracted')
+            transaction.commit()
+            count += 1
+
+        browser = self.getBrowser()
+        invoice_url = '%s/invoice' % ar.absolute_url()
+        browser.open(invoice_url)
+        if '30.00' in browser.contents:
+            self.fail('Retracted Analyses Services found on the invoice')
+        if '20.00' not in browser.contents:
+            self.fail('SubTotal incorrect')
+
+
+    def test_retract_an_analysis_request(self):
+        catalog = getToolByName(self.portal, 'portal_catalog')
+        client = self.portal.clients['client-1']
+        sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+        values = {'Client': client.UID(),
+                  'Contact': client.getContacts()[0].UID(),
+                  'SamplingDate': '2015-01-01',
+                  'SampleType': sampletype.UID()}
+        services = catalog(portal_type = 'AnalysisService',
+                            inactive_state = 'active')[:3]
+        service_uids = [service.getObject().UID() for service in services]
+        request = {}
+        ar = create_analysisrequest(client, request, values, service_uids)
+        transaction.commit()
+        wf = getToolByName(ar, 'portal_workflow')
+        wf.doActionFor(ar, 'receive')
+
+        self.assertEquals(ar.portal_workflow.getInfoFor(ar, 'review_state'),
+                                                        'sample_received')
+        count = 0
+        for analysis in ar.getAnalyses(full_objects=True):
+            analysis.setResult('12')
+            wf.doActionFor(analysis, 'submit')
+            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
+                            'review_state'),'to_be_verified')
+            # Only retract the first one
+            if count == 0:
+                wf.doActionFor(analysis, 'retract')
+                self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
+                                'review_state'),'retracted')
+            transaction.commit()
+            count += 1
+
+        browser = self.getBrowser()
+        invoice_url = '%s/invoice' % ar.absolute_url()
+        browser.open(invoice_url)
+        if '30.00' in browser.contents:
+            self.fail('Retracted Analyses Services found on the invoice')
+        if '20.00' not in browser.contents:
+            self.fail('SubTotal incorrect')
+
+    def tearDown(self):
+        logout()
+        super(TestAnalysisRetract, self).tearDown()
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestAnalysisRetract))
+    suite.layer = BIKA_FUNCTIONAL_TESTING
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/BC-33
https://github.com/bikalabs/bika.lims/issues/


## Current behavior before PR
     Retracted Analysis showing on the invoice
## Desired behavior after PR is merged
      Retracted Analysis not showing on the invoice.
      Please note this PR only covers 3 cases
      1. AR created using a Profile with [Use Analysis Profile Price] option
      2. AR created using a Profile without the [Use Analysis Profile Price] option
      3. AR created without using a profile but using the Analyses Service
      If we have missed a use case please advise. 

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
