### PR TITLE
Batch folder sort order

### DIFF
--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -27,7 +27,7 @@ class BatchFolderContentsView(BikaListingView):
         self.catalog = 'bika_catalog'
         self.contentFilter = {
             'portal_type': 'Batch',
-            'sort_on': 'created',
+            'sort_on': 'BatchDate',
             'sort_order': 'reverse',
             'cancellation_state': 'active'
         }
@@ -45,7 +45,7 @@ class BatchFolderContentsView(BikaListingView):
             'Title': {'title': _('Title')},
             'BatchID': {'title': _('Batch ID')},
             'Description': {'title': _('Description')},
-            'BatchDate': {'title': _('Date')},
+            'BatchDate': {'title': _('Date'), 'index': 'BatchDate'},
             'Client': {'title': _('Client')},
             'state_title': {'title': _('State'), 'sortable': False},
         }

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -528,7 +528,10 @@ class BikaListingView(BrowserView):
         # Precedence is request, sort_on attribute, contentFilter sort_on value
         self.sort_on = getattr(self, "sort_on", self.contentFilter.get("sort_on"))
         self.sort_on = self.request.get(form_id + '_sort_on', self.sort_on)
-        self.sort_order = self.request.get(form_id + '_sort_order', 'ascending')
+        self.sort_order = getattr(
+                self, "sort_order", self.contentFilter.get("sort_order"))
+        self.sort_order = self.request.get(
+                form_id + '_sort_order', self.sort_order)
         self.manual_sort_on = self.request.get(form_id + '_manual_sort_on', None)
 
         if self.sort_on:

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -526,13 +526,16 @@ class BikaListingView(BrowserView):
 
         # SORTING
         # Precedence is request, sort_on attribute, contentFilter sort_on value
-        self.sort_on = getattr(self, "sort_on", self.contentFilter.get("sort_on"))
+        self.sort_on = getattr(
+                self, "sort_on", self.contentFilter.get("sort_on"))
         self.sort_on = self.request.get(form_id + '_sort_on', self.sort_on)
+        # Precedence is request, sort_order attribute, contentFilter value
         self.sort_order = getattr(
                 self, "sort_order", self.contentFilter.get("sort_order"))
         self.sort_order = self.request.get(
                 form_id + '_sort_order', self.sort_order)
-        self.manual_sort_on = self.request.get(form_id + '_manual_sort_on', None)
+        self.manual_sort_on = self.request.get(
+                form_id + '_manual_sort_on', None)
 
         if self.sort_on:
             if self.sort_on in self.columns.keys():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/bikalabs/bika.lims/issues/2109

## Current behavior before PR
BatchFolder sort order not on batch date descending

## Desired behavior after PR is merged
BatchFolder sort order on batch date descending

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
