### PR TITLE
Added simple upgrade step 340

### DIFF
--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>330</version>
+  <version>340</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -587,4 +587,13 @@
          handler="bika.lims.upgrade.to330.upgrade"
          sortkey="1"
          profile="bika.lims:default"/>
+
+ <genericsetup:upgradeStep
+         title="Upgrade to 3.4.0"
+         description="This is the upgrade step to from 3.3.0 to 3.4.0"
+         source="330"
+         destination="340"
+         handler="bika.lims.upgrade.to340.upgrade"
+         sortkey="1"
+         profile="bika.lims:default"/>
 </configure>

--- a/bika/lims/upgrade/to340.py
+++ b/bika/lims/upgrade/to340.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Bika LIMS
+#
+# Copyright 2011-2017 by it's authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+
+import transaction
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from bika.lims import logger
+from bika.lims.idserver import generateUniqueId
+from bika.lims.numbergenerator import INumberGenerator
+from DateTime import DateTime
+from Products.ATContentTypes.utils import DT2dt
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
+from zope.component import getUtility
+
+
+def upgrade(tool):
+    """Upgrade step to prepare for refactored ID Server
+    """
+    portal = aq_parent(aq_inner(tool))
+
+    qi = portal.portal_quickinstaller
+    ufrom = qi.upgradeInfo('bika.lims')['installedVersion']
+    logger.info("Upgrading Bika LIMS: %s -> %s" % (ufrom, '3.4.0'))
+
+    #Do nothing other than prepare for 3.4.0
+
+    return True
+
+


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Master already has code destined for release 3.4.0 (like the refactored ID Server) but the upgrade steps don't reflect this. So this is an attempt to get master into a 3.4.0 ready state.

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
