### PR TITLE
BC-61 Started with Sampling and COC Setup tab

### DIFF
--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -898,6 +898,8 @@ class AnalysisRequestsView(BikaListingView):
     def __call__(self):
         self.workflow = getToolByName(self.context, "portal_workflow")
         self.mtool = getToolByName(self.context, 'portal_membership')
+        portal = self.portal
+        bika_setup = portal.bika_setup
 
         # Only "BIKA: ManageAnalysisRequests" may see the copy to new button.
         # elsewhere it is hacked in where required.
@@ -929,7 +931,18 @@ class AnalysisRequestsView(BikaListingView):
                         state['hide_transitions'].append('preserve')
                     else:
                         state['hide_transitions'] = ['preserve', ]
-            new_states.append(state)
+            exclude_state = False
+            if state['title'] == 'To Be Sampled':
+                if bika_setup.getSamplingWorkflowEnabled():
+                    exclude_state = True
+            if state['title'] == 'Scheduled sampling':
+                if bika_setup.getScheduleSamplingEnabled():
+                    exclude_state = True
+            if state['title'] == 'To Be Preserved':
+                if bika_setup.getSamplePreservationEnabled():
+                    exclude_state = True
+            if not exclude_state:
+                new_states.append(state)
         self.review_states = new_states
 
         return super(AnalysisRequestsView, self).__call__()

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -344,36 +344,6 @@ schema = BikaFolderSchema.copy() + Schema((
     #     )
     # ),
     BooleanField(
-        'SamplingWorkflowEnabled',
-        schemata="Analyses",
-        default=False,
-        widget=BooleanWidget(
-            label=_("Enable the Sampling workflow"),
-            description=_("Select this to activate the sample collection workflow steps.")
-        ),
-    ),
-    BooleanField(
-        'ScheduleSamplingEnabled',
-        schemata="Analyses",
-        default=False,
-        widget=BooleanWidget(
-            label=_("Enable the Schedule a Sampling functionality"),
-            description=_(
-                "Select this to allow a Sampling Coordinator to" +
-                " schedule a sampling. This functionality only takes effect" +
-                " when 'Sampling workflow' is active")
-        ),
-    ),
-    BooleanField(
-        'ShowPartitions',
-        schemata="Analyses",
-        default=True,
-        widget=BooleanWidget(
-            label=_("Display individual sample partitions "),
-            description=_("Turn this on if you want to work with sample partitions")
-        ),
-    ),
-    BooleanField(
         'CategoriseAnalysisServices',
         schemata="Analyses",
         default=False,
@@ -531,19 +501,6 @@ schema = BikaFolderSchema.copy() + Schema((
                 "own configuration"),
         )
     ),
-    DurationField(
-        'DefaultSampleLifetime',
-        schemata="Analyses",
-        required=1,
-        default={"days": 30, "hours": 0, "minutes": 0},
-        widget=DurationWidget(
-            label=_("Default sample retention period"),
-            description=_(
-                "The number of days before a sample expires and cannot be analysed "
-                "any more. This setting can be overwritten per individual sample type "
-                "in the sample types setup"),
-        )
-    ),
     StringField(
         'ResultsDecimalMark',
         schemata="Analyses",
@@ -610,9 +567,88 @@ schema = BikaFolderSchema.copy() + Schema((
             base_query={'review_state': 'published'},
         ),
     ),
+    BooleanField(
+        'SamplingWorkflowEnabled',
+        schemata="Sampling and COC",
+        default=False,
+        widget=BooleanWidget(
+            label=_("Enable Sampling"),
+            description=_("Select this to activate the sample collection workflow steps.")
+        ),
+    ),
+    BooleanField(
+        'ScheduleSamplingEnabled',
+        schemata="Sampling and COC",
+        default=False,
+        widget=BooleanWidget(
+            label=_("Enable Sampling Scheduling"),
+            description=_(
+                "Select this to allow a Sampling Coordinator to" +
+                " schedule a sampling. This functionality only takes effect" +
+                " when 'Sampling workflow' is active")
+        ),
+    ),
+    BooleanField(
+        'ShowPartitions',
+        schemata="Sampling and COC",
+        default=True,
+        widget=BooleanWidget(
+            label=_("Display individual sample partitions "),
+            description=_("Turn this on if you want to work with sample partitions")
+        ),
+    ),
+    DurationField(
+        'DefaultSampleLifetime',
+        schemata="Sampling and COC",
+        required=1,
+        default={"days": 30, "hours": 0, "minutes": 0},
+        widget=DurationWidget(
+            label=_("Default sample retention period"),
+            description=_(
+                "The number of days before a sample expires and cannot be analysed "
+                "any more. This setting can be overwritten per individual sample type "
+                "in the sample types setup"),
+        )
+    ),
+    RecordsField(
+        'RejectionReasons',
+        schemata="Sampling and COC",
+        widget=RejectionSetupWidget(
+            label=_("Enable sampling rejection"),
+            description=_("Select this to activate the rejection workflow "
+                          "for Samples and Analysis Requests. A 'Reject' "
+                          "option will be displayed in the actions menu for "
+                          "these objects.")
+        ),
+    ),
+    BooleanField(
+        'NotifyOnRejection',
+        schemata="Sampling and COC",
+        default=False,
+        widget=BooleanWidget(
+            label=_("Sample rejection email notification"),
+            description=_("Select this to activate automatic notifications "
+                          "via email to the Client when a Sample or Analysis "
+                          "Request is rejected.")
+        ),
+    ),
+    StringField(
+        'COCAttestationStatement',
+        schemata="Sampling and COC",
+        widget=StringWidget(
+            label=_("COC Attestation Statement"),
+        )
+    ),
+    StringField(
+        'COCFooter',
+        schemata="Sampling and COC",
+        widget=StringWidget(
+            label=_("COC Footer"),
+        )
+    ),
     StringField(
         'AutoPrintStickers',
-        schemata="Stickers",
+        schemata="Sampling and COC",
         vocabulary=STICKER_AUTO_OPTIONS,
         widget=SelectionWidget(
             format='select',
@@ -625,7 +661,7 @@ schema = BikaFolderSchema.copy() + Schema((
     ),
     StringField(
         'AutoStickerTemplate',
-        schemata="Stickers",
+        schemata="Sampling and COC",
         vocabulary="getStickerTemplates",
         widget=SelectionWidget(
             format='select',
@@ -635,7 +671,7 @@ schema = BikaFolderSchema.copy() + Schema((
     ),
     StringField(
         'SmallStickerTemplate',
-        schemata="Stickers",
+        schemata="Sampling and COC",
         vocabulary="getStickerTemplates",
         default="Code_128_1x48mm.pt",
         widget=SelectionWidget(
@@ -646,7 +682,7 @@ schema = BikaFolderSchema.copy() + Schema((
     ),
     StringField(
         'LargeStickerTemplate',
-        schemata="Stickers",
+        schemata="Sampling and COC",
         vocabulary="getStickerTemplates",
         default="Code_128_1x72mm.pt",
         widget=SelectionWidget(
@@ -717,28 +753,6 @@ Configuration Settings:
             label=_("ID Server Values"),
             cols=30,
             rows=30,
-        ),
-    ),
-    RecordsField(
-        'RejectionReasons',
-        schemata="Analyses",
-        widget=RejectionSetupWidget(
-            label=_("Enable the rejection workflow"),
-            description=_("Select this to activate the rejection workflow "
-                          "for Samples and Analysis Requests. A 'Reject' "
-                          "option will be displayed in the actions menu for "
-                          "these objects.")
-        ),
-    ),
-    BooleanField(
-        'NotifyOnRejection',
-        schemata="Analyses",
-        default=False,
-        widget=BooleanWidget(
-            label=_("Email notification on rejection"),
-            description=_("Select this to activate automatic notifications "
-                          "via email to the Client when a Sample or Analysis "
-                          "Request is rejected.")
         ),
     ),
     BooleanField(

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -597,6 +597,15 @@ schema = BikaFolderSchema.copy() + Schema((
             description=_("Turn this on if you want to work with sample partitions")
         ),
     ),
+    BooleanField(
+        'SamplePreservationEnabled',
+        schemata="Sampling and COC",
+        default=False,
+        widget=BooleanWidget(
+            label=_("Enable Sample Preservation"),
+            description=_("")
+        ),
+    ),
     DurationField(
         'DefaultSampleLifetime',
         schemata="Sampling and COC",

--- a/bika/lims/docs/SamplingCOCSetupTab.rst
+++ b/bika/lims/docs/SamplingCOCSetupTab.rst
@@ -1,7 +1,8 @@
 SamplingCOCSetupTab
 ===================
 
-The ID Server in Bika LIMS provides IDs for content items base of the given format specification. The format string is constructed in the same way as a python format() method based predefined variables per content type. The only variable available to all type is 'seq'. Currently, seq can be constructed either using number generator or a counter of existing items. For generated IDs, one can specifypoint at which the format string will be split to create the generator key. For counter IDs, one must specify context and the type of counter which is either the number of backreferences or the number of contained objects.
+Sampling COC Setup tab is a tab on BIKA Setup and has a fields that manage
+the filters on ARs listing view.
 
 
 Running this test from the buildout directory::

--- a/bika/lims/docs/SamplingCOCSetupTab.rst
+++ b/bika/lims/docs/SamplingCOCSetupTab.rst
@@ -1,0 +1,120 @@
+SamplingCOCSetupTab
+===================
+
+The ID Server in Bika LIMS provides IDs for content items base of the given format specification. The format string is constructed in the same way as a python format() method based predefined variables per content type. The only variable available to all type is 'seq'. Currently, seq can be constructed either using number generator or a counter of existing items. For generated IDs, one can specifypoint at which the format string will be split to create the generator key. For counter IDs, one must specify context and the type of counter which is either the number of backreferences or the number of contained objects.
+
+
+Running this test from the buildout directory::
+
+    bin/test test_textual_doctests -t SamplingCOCSetupTab
+
+
+Test Setup
+----------
+
+
+    >>> from DateTime import DateTime
+    >>> from plone import api as ploneapi
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+
+    >>> import transaction
+    >>> from plone import api as ploneapi
+    >>> from zope.lifecycleevent import modified
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+    >>> portal = self.getPortal()
+    >>> portal_url = portal.absolute_url()
+    >>> bika_setup = portal.bika_setup
+    >>> bika_setup_url = portal_url + "/bika_setup"
+    >>> from bika.lims import api
+
+Variables::
+
+    >>> sample_date = DateTime(2017, 1, 31)
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bika_setup = portal.bika_setup
+    >>> bika_sampletypes = bika_setup.bika_sampletypes
+    >>> bika_samplepoints = bika_setup.bika_samplepoints
+    >>> bika_analysiscategories = bika_setup.bika_analysiscategories
+    >>> bika_analysisservices = bika_setup.bika_analysisservices
+    >>> bika_labcontacts = bika_setup.bika_labcontacts
+    >>> portal_url = portal.absolute_url()
+    >>> bika_setup_url = portal_url + "/bika_setup"
+
+
+Analysis Requests (AR)
+----------------------
+
+An `AnalysisRequest` can only be created inside a `Client`::
+
+    >>> clients = self.portal.clients
+    >>> client = api.create(clients, "Client", Name="RIDING BYTES", ClientID="RB")
+    >>> client
+    <Client at /plone/clients/client-1>
+
+To create a new AR, a `Contact` is needed::
+
+    >>> contact = api.create(client, "Contact", Firstname="Ramon", Surname="Bartl")
+    >>> contact
+    <Contact at /plone/clients/client-1/contact-1>
+
+A `SampleType` defines how long the sample can be retained, the minimum volume
+needed, if it is hazardous or not, the point where the sample was taken etc.::
+
+    >>> sampletype = api.create(bika_sampletypes, "SampleType", Prefix="water", MinimumVolume="100 ml")
+    >>> sampletype
+    <SampleType at /plone/bika_setup/bika_sampletypes/sampletype-1>
+
+A `SamplePoint` defines the location, where a `Sample` was taken::
+
+    >>> samplepoint = api.create(bika_samplepoints, "SamplePoint", title="Lake of Constance")
+    >>> samplepoint
+    <SamplePoint at /plone/bika_setup/bika_samplepoints/samplepoint-1>
+
+An `AnalysisCategory` categorizes different `AnalysisServices`::
+
+    >>> analysiscategory = api.create(bika_analysiscategories, "AnalysisCategory", title="Water")
+    >>> analysiscategory
+    <AnalysisCategory at /plone/bika_setup/bika_analysiscategories/analysiscategory-1>
+
+An `AnalysisService` defines a analysis service offered by the laboratory::
+
+    >>> analysisservice = api.create(bika_analysisservices, "AnalysisService", title="PH", ShortTitle="ph", Category=analysiscategory, Keyword="PH")
+    >>> analysisservice
+    <AnalysisService at /plone/bika_setup/bika_analysisservices/analysisservice-1>
+
+An `AnalysisRequest` can be created::
+
+    >>> values = {
+    ...           'Client': client,
+    ...           'Contact': contact,
+    ...           'SamplingDate': sample_date,
+    ...           'DateSampled': sample_date,
+    ...           'SampleType': sampletype
+    ...          }
+
+    >>> service_uids = [analysisservice.UID()]
+    >>> ar = create_analysisrequest(client, request, values, service_uids)
+    >>> transaction.commit()
+    >>> browser = self.getBrowser()
+    >>> ars_url = portal_url + '/analysisrequests'
+    >>> browser.open(ars_url)
+    >>> 'To Be Sampled' and 'To Be Preserved' and 'Scheduled sampling' in browser.contents
+    True
+    >>> bika_setup.setSamplingWorkflowEnabled(True)
+    >>> bika_setup.setScheduleSamplingEnabled(True)
+    >>> bika_setup.setSamplePreservationEnabled(True)
+    >>> transaction.commit()
+    >>> browser.open(ars_url)
+    >>> 'To Be Sampled' and 'To Be Preserved' and 'Scheduled sampling' not in browser.contents
+    True
+    >>> 'Analysis Requests' in browser.contents
+    True
+
+

--- a/bika/lims/tests/test_textual_doctests.py
+++ b/bika/lims/tests/test_textual_doctests.py
@@ -26,6 +26,7 @@ DOCTESTS = [
     "../docs/Calculations.rst",
     "../docs/IDServer.rst",
     "../docs/Rolemap.rst",
+    "../docs/SamplingCOCSetupTab.rst",
 ]
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/BC-61
https://github.com/bikalabs/bika.lims/issues/2094


## Current behavior before PR
      Stickers tab in Bika Setup and Enable Sampling, Enable Sampling Scheduling
      Display individual Sample Partitions,Default Sample Retention Period
      Enable Sample Rejection, Sample Rejection email notification are on Analyses tab in Bika Setup
 
## Desired behavior after PR is merged
     BC-61
     Change Stickers tab to Sampling and COC and move Enable Sampling, Enable Sampling Scheduling
     Display individual Sample Partitions,Default Sample Retention Period
     Enable Sample Rejection, Sample Rejection email notification from  on Analyses tab to Sampling 
     and COC tab and also add 2 news fields COC Attestation Statement and COC Footer under 
     Sampling and COC tab
 
     GITHUB issue 2094
     Display list filters to correspond with Bika Setup
    To be Sampled, Scheduled Sampling  and To Be Preserved filter buttons do not have to be 
    displayed if deselected in the Bika set-up

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
