### PR TITLE
BC-83 Select Template dropdown now shows Worksheet templates

### DIFF
--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -459,7 +459,11 @@ class FolderView(BikaListingView):
         """ List of templates
             Used in bika_listing.pt
         """
-        return DisplayList(self.templates)
+        bsc = getToolByName(self.context, 'bika_setup_catalog')
+        return DisplayList([(c.UID, c.Title) for c in
+                bsc(portal_type = 'WorksheetTemplate',
+                   inactive_state = 'active',
+                   sort_on = 'sortable_title')])
 
     def getInstruments(self):
         """ List of instruments


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/BC-83
https://github.com/bikalabs/bika.lims/issues/


## Current behavior before PR
     Worksheet Templates not listed for WS Create
## Desired behavior after PR is merged
     On the Select template drop down show the Worksheet Templates
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
