### PR TITLE
Issue 2128: Fixed infinite recursion if now 

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -522,7 +522,7 @@ class AnalysisRequestPublishView(BrowserView):
         client_address = client.getPostalAddress()
         if not client_address:
             # Data from the first contact
-            contact = self.getAnalysisRequest().getContact()
+            contact = self.getAnalysisRequestObj().getContact()
             if contact and contact.getBillingAddress():
                 client_address = contact.getBillingAddress()
             elif contact and contact.getPhysicalAddress():

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1b3 (unreleased)
 --------------------
 
+- Issue-2128: Infinite Recursion on Report Publication
 - Issue-2095: Permission of getAccreditationBodyLogo
 - Issue-2065: Sort order on all landing pages are broken
 - Issue-2081: Fixed multiple partition creation from ARTemple


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalabs/bika.lims/issues/2128 for further details.

## Current behavior before PR

Infinite recursion if no Address details were found on the Client or Contact.

## Desired behavior after PR is merged

Rendering succeeds w/o Address Details.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
