### PR TITLE
Issue-2129: Migrate Attachment files to blob

### DIFF
--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -159,8 +159,10 @@ class AnalysisRequestViewView(BrowserView):
         ar_atts = self.context.getAttachment()
         analyses = self.context.getAnalyses(full_objects=True)
         for att in ar_atts:
+            fsize = 0
             file = att.getAttachmentFile()
-            fsize = file.getSize() if file else 0
+            if file:
+                fsize = file.get_size()
             if fsize < 1024:
                 fsize = '%s b' % fsize
             else:

--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -183,7 +183,7 @@ class AnalysisRequestViewView(BrowserView):
             an_atts = analysis.getAttachment()
             for att in an_atts:
                 file = att.getAttachmentFile()
-                fsize = file.getSize() if file else 0
+                fsize = file.get_size() if file else 0
                 if fsize < 1024:
                     fsize = '%s b' % fsize
                 else:

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -17,7 +17,6 @@ from Products.Archetypes.atapi import BaseFolder
 from Products.Archetypes.atapi import registerType
 from Products.Archetypes.atapi import ComputedField
 from Products.Archetypes.atapi import ComputedWidget
-from Products.Archetypes.atapi import FileField
 from Products.Archetypes.atapi import FileWidget
 from Products.Archetypes.atapi import ReferenceField
 from Products.Archetypes.atapi import ReferenceWidget
@@ -26,6 +25,8 @@ from Products.Archetypes.atapi import StringWidget
 from Products.Archetypes.atapi import DateTimeField
 from Products.Archetypes.atapi import SelectionWidget
 from Products.Archetypes.config import REFERENCE_CATALOG
+
+from plone.app.blob.field import FileField
 
 from bika.lims.config import PROJECTNAME
 from bika.lims.config import ATTACHMENT_REPORT_OPTIONS

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>320</version>
+  <version>330</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -578,4 +578,14 @@
          handler="bika.lims.upgrade.to320.upgrade"
          sortkey="1"
          profile="bika.lims:default"/>
+
+ <genericsetup:upgradeStep
+         title="Upgrade to Bika LIMS 3.3.0"
+         description="This is the upgrade step to drive bikaLIMS ot 3.3.0 version."
+         source="3210"
+         destination="330"
+         handler="bika.lims.upgrade.to330.upgrade"
+         sortkey="1"
+         profile="bika.lims:default"/>
+
 </configure>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -582,7 +582,7 @@
  <genericsetup:upgradeStep
          title="Upgrade to Bika LIMS 3.3.0"
          description="This is the upgrade step to drive bikaLIMS ot 3.3.0 version."
-         source="3210"
+         source="320"
          destination="330"
          handler="bika.lims.upgrade.to330.upgrade"
          sortkey="1"

--- a/bika/lims/upgrade/to330.py
+++ b/bika/lims/upgrade/to330.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Bika LIMS
+#
+# Copyright 2011-2017 by it's authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+
+from bika.lims import api
+from bika.lims import logger
+
+
+def upgrade(tool):
+    """Upgrade step required for Bika LIMS 3.3.0
+    """
+    portal = aq_parent(aq_inner(tool))
+
+    qi = portal.portal_quickinstaller
+    ufrom = qi.upgradeInfo('bika.lims')['installedVersion']
+    logger.info("Upgrading Bika LIMS: %s -> %s" % (ufrom, '3.3.0'))
+
+    upgrade_attachments_to_blobs(portal)
+
+
+def upgrade_attachments_to_blobs(portal):
+    """get/set the attachment file fields to migrate existing fields to blob
+    """
+    logger.info("Upgrading Attachments to Blobs")
+
+    pc = api.get_tool("portal_catalog")
+    attachments = map(api.get_object, pc({"portal_type": "Attachment"}))
+    for attachment in attachments:
+        attachment.setAttachmentFile(attachment.getAttachmentFile())

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.3.0 (unreleased)
 ------------------
 
+- Issue-2129: Migrate Attachments to blobs
 - Issue-2098: Inline rendered Attachments not in final PDF
 - LIMS-2596:  AR and Sample view fields that need to stay editable
 - Issue-2128: Infinite Recursion on Report Publication


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalabs/bika.lims/issues/2129 for any more details.

## Current behavior before PR

Attachment files get stored in the Data.fs.

## Desired behavior after PR is merged

Attachment files get stored in the Blobstorage

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
