### PR TITLE
Bc subject of email

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -1073,7 +1073,7 @@ class AnalysisRequestPublishView(BrowserView):
         """
         client = ar.aq_parent
         subject_items = client.getEmailSubject()
-        ai = co = cr = cs = False
+        ai = co = cr = cs = cn = False
         if 'ar' in subject_items:
             ai = True
         if 'co' in subject_items:
@@ -1082,10 +1082,13 @@ class AnalysisRequestPublishView(BrowserView):
             cr = True
         if 'cs' in subject_items:
             cs = True
+        if 'cn' in subject_items:
+            cn = True
         ais = []
         cos = []
         crs = []
         css = []
+        cns = []
         blanks_found = False
         if ai:
             ais.append(ar.getRequestID())
@@ -1109,6 +1112,8 @@ class AnalysisRequestPublishView(BrowserView):
                     css.append(sample.getClientSampleID())
             else:
                 blanks_found = True
+        if cn:
+            cns.append(ar.getClientTitle())
         line_items = []
         if ais:
             ais.sort()
@@ -1125,6 +1130,10 @@ class AnalysisRequestPublishView(BrowserView):
         if css:
             css.sort()
             li = t(_('Samples: ${samples}', mapping={'samples': ', '.join(css)}))
+            line_items.append(li)
+        if cns:
+            cns.sort()
+            li = t(_('Client: ${client}', mapping={'client': ', '.join(cns)}))
             line_items.append(li)
         tot_line = ' '.join(line_items)
         if tot_line:

--- a/bika/lims/config.py
+++ b/bika/lims/config.py
@@ -79,6 +79,7 @@ EMAIL_SUBJECT_OPTIONS = DisplayList((
     ('co', _('Order ID')),
     ('cr', _('Client Reference')),
     ('cs', _('Client SID')),
+    ('cn', _('Client Name')),
 ))
 
 GENDERS = DisplayList((

--- a/bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
@@ -136,7 +136,7 @@
     </guard>
   </transition>
 
-  <transition transition_id="unassign" title="Unsassign" new_state="unassigned" trigger="USER" before_script="" after_script="" i18n:attributes="title">
+  <transition transition_id="unassign" title="Unassign" new_state="unassigned" trigger="USER" before_script="" after_script="" i18n:attributes="title">
     <action url="" category="workflow" icon="">Remove</action>
     <guard>
     </guard>

--- a/bika/lims/upgrade/to340.py
+++ b/bika/lims/upgrade/to340.py
@@ -24,10 +24,12 @@ def upgrade(tool):
     portal = aq_parent(aq_inner(tool))
 
     qi = portal.portal_quickinstaller
+    setup = portal.portal_setup
     ufrom = qi.upgradeInfo('bika.lims')['installedVersion']
     logger.info("Upgrading Bika LIMS: %s -> %s" % (ufrom, '3.4.0'))
 
     #Do nothing other than prepare for 3.4.0
+    setup.runImportStepFromProfile('profile-bika.lims:default', 'workflow')
 
     return True
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/BC-88
https://jira.bikalabs.com/browse/BC-84


## Current behavior before PR
      BC-88: On Client preferences there isn't an to choose <Client Name> as subject of email
      BC-84: Typo on WS button 
## Desired behavior after PR is merged
     On Client preferences add <Client Name> as subject of email option

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
