### PR TITLE
Issue 2152 auto print sticker on receipt

### DIFF
--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -470,7 +470,7 @@ class ajaxAnalysisRequestSubmit():
         self.context.plone_utils.addPortalMessage(message, 'info')
         # Automatic label printing won't print "register" labels for Secondary. ARs
         #This was a hack and is still a hack but will work more widely
-        new_ars = [ar for ar in ARs if ar[-2:] == '1']
+        new_ars = [ar for ar in ARs if ar[-1] == '1']
         if 'register' in self.context.bika_setup.getAutoPrintStickers() \
                 and new_ars:
             return json.dumps({

--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -469,7 +469,8 @@ class ajaxAnalysisRequestSubmit():
                         mapping={'AR': safe_unicode(ARs[0])})
         self.context.plone_utils.addPortalMessage(message, 'info')
         # Automatic label printing won't print "register" labels for Secondary. ARs
-        new_ars = [ar for ar in ARs if ar[-2:] == '01']
+        #This was a hack and is still a hack but will work more widely
+        new_ars = [ar for ar in ARs if ar[-2:] == '1']
         if 'register' in self.context.bika_setup.getAutoPrintStickers() \
                 and new_ars:
             return json.dumps({

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -5,6 +5,7 @@
 - Issue-2143: Make Bika API work with DX types properly
 - LIMS-2449: Thermo Qtegra results importer
 - Lab Supervisor field on the Laboratory(Bika Setup - Laboratory Information)
+- Issue-2152: Fixed AR sticker autoprint to work regardless of AR number format
 
 
 3.3.0 (unreleased)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
If one changed the AR number format to not be left padded with zeros, after AR creation it does not go to the sticker preview page.

https://github.com/bikalabs/bika.lims/issues/2152


## Current behavior before PR
If one changed the AR number format to not be left padded with zeros, after AR creation it does not go to the sticker preview page.

## Desired behavior after PR is merged
If one changed the AR number format to not be left padded with zeros, after AR creation it DOES go to the sticker preview page.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
