### PR TITLE
Fixed bug in RenameAfterCreation to allow Bika ID server to be ignored

### DIFF
--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -148,7 +148,7 @@ def renameAfterCreation(obj):
     """Rename the content after it was created/added
     """
     # Check if the _bika_id was aready set
-    bika_id = getattr(object, "_bika_id", None)
+    bika_id = getattr(obj, "_bika_id", None)
     if bika_id is not None:
         return bika_id
     # Can't rename without a subtransaction commit when using portal_factory


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
RenameAfterCreation provided the ability to bypass the Bika ID generator but did not work

https://github.com/bikalabs/bika.lims/issues/2155


## Current behavior before PR
Providing the _bika_id field to plone.api.create does not bypass the Bika ID generator

## Desired behavior after PR is merged
Providing the _bika_id field to plone.api.create does bypass the Bika ID generator

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
