### PR TITLE
Change Attestation field from String to TextArea

### DIFF
--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -641,10 +641,10 @@ schema = BikaFolderSchema.copy() + Schema((
                           "Request is rejected.")
         ),
     ),
-    StringField(
+    TextField(
         'COCAttestationStatement',
         schemata="Sampling and COC",
-        widget=StringWidget(
+        widget=TextAreaWidget(
             label=_("COC Attestation Statement"),
         )
     ),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
User request more text space for the Attestation field on bika_setup

https://jira.bikalabs.com/browse/BC-101

## Current behavior before PR
Field used StringWidget

## Desired behavior after PR is merged
Field uses a TextAreaWidget
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
