### PR TITLE
Added renameAfterCreation to partition creation in ARImport

### DIFF
--- a/bika/lims/content/arimport.py
+++ b/bika/lims/content/arimport.py
@@ -335,10 +335,10 @@ class ARImport(BaseFolder):
                 return user_ids[0]
             if len(user_ids) > 1:
                 #raise ValueError('Sampler %s is ambiguous' % import_user)
-                return None
+                return ''
             #Otherwise
             #raise ValueError('Sampler %s not found' % import_user)
-            return None
+            return ''
 
         bsc = getToolByName(self, 'bika_setup_catalog')
         workflow = getToolByName(self, 'portal_workflow')

--- a/bika/lims/content/arimport.py
+++ b/bika/lims/content/arimport.py
@@ -371,6 +371,7 @@ class ARImport(BaseFolder):
                 workflow.doActionFor(sample, 'no_sampling_workflow')
             part = _createObjectByType('SamplePartition', sample, 'part-1')
             part.unmarkCreationFlag()
+            renameAfterCreation(part)
             if swe:
                 workflow.doActionFor(part, 'sampling_workflow')
             else:

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2162: Added renameAfterCreation to partition creation in ARImport
 - Laboratory Supervisor field on the Laboratory(Bika Setup - Laboratory Information)
 - Laboratory License ID field on the Laboratory(Bika Setup - Laboratory Information)
 - Add instrument Agilent-Masshunter


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/bikalabs/bika.lims/issues/2162


## Current behavior before PR
      Partitions were not created from AR Import using ID server

## Desired behavior after PR is merged
      Add renameAfterCreation to partition creation in ARImport
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
