### PR TITLE
Fixed Loading of setup data from a file

### DIFF
--- a/bika/lims/exportimport/load_setup_data.py
+++ b/bika/lims/exportimport/load_setup_data.py
@@ -85,10 +85,10 @@ class LoadSetupData(BrowserView):
                     print traceback.format_exc()
                     print "Error while loading ", path
 
-        elif 'setupfile' in form and 'file' in form and form['file'] and 'projectname' in form and form['projectname']:
+        elif 'setupfile' in form and 'import_file' in form and form['import_file'] and 'projectname' in form and form['projectname']:
                 self.dataset_project = form['projectname']
-                tmp = tempfile.mktemp()
-                file_content = form['file'].read()
+                tmp = "{}.xlsx".format(tempfile.mktemp())
+                file_content = form['import_file'].read()
                 open(tmp, 'wb').write(file_content)
                 workbook = load_workbook(filename=tmp)  # , use_iterators=True)
                 self.dataset_name = 'uploaded'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/LIMS-2165

## Current behavior before PR
Fails when trying to load setup data from a file

## Desired behavior after PR is merged
Load the setup data
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
